### PR TITLE
fix: show "Done" badge instead of "Ready" for merged PRs

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -438,6 +438,8 @@
                 {:else}
                   <button class="status-badge mergeable" onclick={handlePrAction}>Merge #{wsPr.number}</button>
                 {/if}
+              {:else if wsPr && wsPr.state === "merged"}
+                <span class="status-badge merged">Done</span>
               {:else if selectedWs.status === "waiting"}
                 <span class="status-badge waiting">Ready</span>
               {/if}
@@ -735,6 +737,11 @@
   .status-badge.waiting {
     color: var(--status-ok);
     border-color: color-mix(in srgb, var(--status-ok) 40%, transparent);
+  }
+
+  .status-badge.merged {
+    color: var(--text-dim);
+    border-color: var(--border-light);
   }
 
   .status-badge.pr-open {


### PR DESCRIPTION
## Summary
- Workspaces with a merged PR incorrectly showed "Ready" status badge
- Added a `merged` state check so they now display "Done" with a dim style matching the gray sidebar dot

## Test plan
- Open a workspace whose PR has been merged
- Verify the tab bar shows "Done" (gray/dim) instead of "Ready" (green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)