### PR TITLE
fix: prevent PR poll from thrashing DOM and breaking terminal

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -126,7 +126,7 @@
           refreshPrStatus(wsId);
         }
       }
-    }, 5000);
+    }, 15_000);
 
     return () => {
       unlistenFn?.();
@@ -325,6 +325,10 @@
       const files = await getChangedFiles(wsId);
       const adds = files.reduce((s, f) => s + f.additions, 0);
       const dels = files.reduce((s, f) => s + f.deletions, 0);
+      const prev = changeCounts.get(wsId);
+      if (prev && prev.additions === adds && prev.deletions === dels) {
+        return; // No change — skip reactive update
+      }
       changeCounts.set(wsId, { additions: adds, deletions: dels });
       changeCounts = new Map(changeCounts);
     } catch {
@@ -333,9 +337,23 @@
   }
 
   // Refresh PR status (slow, network call — run in background)
+  // Only triggers reactivity when the status actually changed to avoid DOM thrash.
   async function refreshPrStatus(wsId: string) {
     try {
       const pr = await getPrStatus(wsId);
+      const prev = prStatusMap.get(wsId);
+      if (
+        prev &&
+        prev.state === pr.state &&
+        prev.checks === pr.checks &&
+        prev.mergeable === pr.mergeable &&
+        prev.number === pr.number &&
+        prev.additions === pr.additions &&
+        prev.deletions === pr.deletions &&
+        prev.title === pr.title
+      ) {
+        return; // No change — skip reactive update
+      }
       prStatusMap.set(wsId, pr);
       prStatusMap = new Map(prStatusMap);
     } catch {


### PR DESCRIPTION
## Summary
- `refreshPrStatus` and `refreshChangeCounts` were creating new `Map` references every poll tick, triggering Svelte reactivity across TitleBar, Sidebar, tab bar, and DiffViewer even when data was identical
- Added shallow equality checks to bail early when nothing changed, eliminating unnecessary DOM updates that caused badge blinking and terminal state loss
- Fixed poll interval from 5s to the intended 15s

## Test plan
- [ ] Open a workspace with a PR, verify status badge stays stable (no blinking) across poll cycles
- [ ] Switch to terminal tab during poll — verify terminal state is preserved
- [ ] Merge/update the PR and confirm the badge updates when status actually changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)