### PR TITLE
fix: persist terminal instances across workspace and tab switches

### DIFF
--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -78,8 +78,10 @@
   onMount(() => {
     if (!containerEl) return;
 
-    // Use ResizeObserver to detect when container becomes visible
+    // Use ResizeObserver to detect when container becomes visible.
+    // Guard fit() against zero dimensions (display:none when tab not active).
     resizeObserver = new ResizeObserver(() => {
+      if (!containerEl || containerEl.offsetHeight === 0) return;
       if (!opened) {
         initTerminal();
       } else if (fitAddon && term) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -550,11 +550,19 @@
               </div>
             {/if}
 
-            {#if activeTab === "terminal" && selectedWs}
-              <div class="ws-tab-container active-layer">
-                <TerminalView workspaceId={selectedWs.id} />
+            <!-- Terminal: always mounted per workspace, toggle display.
+                 Uses display:none (not visibility:hidden) so xterm.js only
+                 inits when it has real dimensions via ResizeObserver. -->
+            {#each activeWorkspaces as ws (ws.id)}
+              {@const isVisible = activeTab === "terminal" && ws.id === selectedWsId}
+              <div
+                class="ws-terminal-layer"
+                class:visible={isVisible}
+                inert={!isVisible}
+              >
+                <TerminalView workspaceId={ws.id} />
               </div>
-            {/if}
+            {/each}
           </div>
         {:else}
           <div class="panel-empty">
@@ -932,6 +940,21 @@
   .ws-tab-container.active-layer {
     position: absolute;
     inset: 0;
+    z-index: 2;
+  }
+
+  /* Terminal layers: kept alive per workspace, toggled via display.
+     display:none gives zero dimensions so xterm.js defers init until visible. */
+  .ws-terminal-layer {
+    position: absolute;
+    inset: 0;
+    display: none;
+    flex-direction: column;
+    z-index: 0;
+  }
+
+  .ws-terminal-layer.visible {
+    display: flex;
     z-index: 2;
   }
 


### PR DESCRIPTION
## Summary
- Terminal tab used `{#if}` (mount/unmount on demand), causing the terminal to carry over when switching workspaces (Svelte reused the component without reinit) and go blank when switching tabs (backend refused to rewire the Channel to a new xterm instance)
- Now uses `{#each activeWorkspaces}` with `display:none`/`display:flex` toggling — same pattern as ChatPanel — so terminal instances stay alive across workspace and tab switches
- Added a guard in ResizeObserver to skip `fitAddon.fit()` when container has zero dimensions (hidden via display:none)

## Test plan
- [ ] Open workspace A → terminal tab → verify shell works
- [ ] Switch to workspace B → terminal tab → verify it's a separate shell (not workspace A's)
- [ ] Switch back to workspace A terminal → verify previous session is preserved
- [ ] From terminal tab, switch to chat, then back to terminal → verify no blank screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)