### PR TITLE
fix: sort sidebar workspaces by creation time

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -15,7 +15,9 @@
     $props();
 
   let activeWorkspaces = $derived(
-    workspaces.filter((w) => w.status !== "archived"),
+    workspaces
+      .filter((w) => w.status !== "archived")
+      .sort((a, b) => a.created_at - b.created_at),
   );
 
   let editingId = $state<string | null>(null);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,7 +56,9 @@
 
   let selectedWs = $derived(workspaces.find((w) => w.id === selectedWsId));
   let activeWorkspaces = $derived(
-    workspaces.filter((w) => w.status !== "archived"),
+    workspaces
+      .filter((w) => w.status !== "archived")
+      .sort((a, b) => a.created_at - b.created_at),
   );
 
   function setSending(wsId: string, value: boolean) {
@@ -109,9 +111,8 @@
           if (!inInput && e.key >= "1" && e.key <= "9") {
             e.preventDefault();
             const idx = parseInt(e.key) - 1;
-            const active = workspaces.filter((w) => w.status !== "archived");
-            if (idx < active.length) {
-              selectWorkspace(active[idx].id);
+            if (idx < activeWorkspaces.length) {
+              selectWorkspace(activeWorkspaces[idx].id);
             }
           }
       }


### PR DESCRIPTION
## Summary
- Sort `activeWorkspaces` by `created_at` in both Sidebar and page components so workspace order is deterministic regardless of how items enter the array (creation, refresh merge, archive-restore)
- Reuse the sorted `activeWorkspaces` derived in the ⌘1-9 keyboard handler instead of computing an unsorted filter inline