### PR TITLE
feat: add remove repository button to settings panel

### DIFF
--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -4,20 +4,23 @@
     listGhProfiles, setRepoProfile, type GhProfile,
   } from "$lib/ipc";
   import { onMount } from "svelte";
-  import { ArrowLeft, Terminal, Bot, GitBranch } from "lucide-svelte";
+  import { ArrowLeft, Terminal, Bot, GitBranch, Trash2 } from "lucide-svelte";
   import { getCurrentWindow } from "@tauri-apps/api/window";
 
   interface Props {
     repoId: string;
     repoName: string;
+    repoPath: string;
     currentProfile: string | null;
     onClose: () => void;
+    onRemoveRepo: () => void;
   }
 
-  let { repoId, repoName, currentProfile, onClose }: Props = $props();
+  let { repoId, repoName, repoPath, currentProfile, onClose, onRemoveRepo }: Props = $props();
 
   type Section = "scripts" | "agent" | "git";
   let activeSection = $state<Section>("scripts");
+  let confirmingRemove = $state(false);
 
   let settings = $state<RepoSettings>({
     setup_script: "",
@@ -95,6 +98,10 @@
     <div class="nav-footer">
       <span class="nav-repo-label">Repository</span>
       <span class="nav-repo-name">{repoName}</span>
+      <button class="remove-repo-btn" onclick={() => (confirmingRemove = true)}>
+        <Trash2 size={12} />
+        Remove
+      </button>
     </div>
   </nav>
 
@@ -222,6 +229,22 @@
       </div>
     {/if}
   </main>
+
+  {#if confirmingRemove}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="confirm-overlay" onmousedown={() => (confirmingRemove = false)}>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="confirm-dialog" onmousedown={(e) => e.stopPropagation()}>
+        <h2>Remove repository?</h2>
+        <p>This will remove <strong>{repoName}</strong> from Korlap and archive all its workspaces. The repository itself won't be deleted.</p>
+        <p class="confirm-path">{repoPath}</p>
+        <div class="confirm-actions">
+          <button class="confirm-cancel" onclick={() => (confirmingRemove = false)}>Cancel</button>
+          <button class="confirm-remove" onclick={onRemoveRepo}>Remove</button>
+        </div>
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -513,5 +536,109 @@
     margin-top: 0.5rem;
     font-size: 0.72rem;
     color: var(--text-dim);
+  }
+
+  /* ── Remove repo button ─────────────── */
+
+  .remove-repo-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+    padding: 0.35rem 0;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.72rem;
+  }
+
+  .remove-repo-btn:hover {
+    color: var(--error, #c87e7e);
+  }
+
+  /* ── Confirmation dialog ────────────── */
+
+  .confirm-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+  }
+
+  .confirm-dialog {
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    padding: 1.5rem;
+    max-width: 380px;
+    width: 90%;
+  }
+
+  .confirm-dialog h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-bright);
+  }
+
+  .confirm-dialog p {
+    margin: 0 0 0.5rem;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    line-height: 1.45;
+  }
+
+  .confirm-path {
+    font-family: var(--font-mono);
+    font-size: 0.72rem !important;
+    color: var(--text-dim) !important;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.3rem 0.5rem;
+    word-break: break-all;
+  }
+
+  .confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+
+  .confirm-cancel {
+    padding: 0.4rem 0.85rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.82rem;
+  }
+
+  .confirm-cancel:hover {
+    background: var(--bg-hover);
+  }
+
+  .confirm-remove {
+    padding: 0.4rem 0.85rem;
+    background: color-mix(in srgb, var(--error, #c87e7e) 15%, var(--bg-card));
+    border: 1px solid color-mix(in srgb, var(--error, #c87e7e) 40%, transparent);
+    border-radius: 6px;
+    color: var(--error, #c87e7e);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+
+  .confirm-remove:hover {
+    background: color-mix(in srgb, var(--error, #c87e7e) 25%, var(--bg-card));
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { open } from "@tauri-apps/plugin-dialog";
   import {
     addRepo,
+    removeRepo,
     listRepos,
     createWorkspace,
     archiveWorkspace,
@@ -171,6 +172,27 @@
     }).catch((e) => { error = String(e); });
 
     getRepoSettings(repo.id).then((s) => { repoSettings = s; }).catch(() => {});
+  }
+
+  async function handleRemoveRepo() {
+    if (!activeRepo) return;
+    const repoId = activeRepo.id;
+    error = "";
+
+    try {
+      await removeRepo(repoId);
+      showSettings = false;
+      repos = repos.filter((r) => r.id !== repoId);
+      workspaces = [];
+      selectedWsId = null;
+      sendingMap.clear();
+      prStatusMap.clear();
+      changeCounts.clear();
+      activeRepo = repos.length > 0 ? repos[0] : null;
+      if (activeRepo) selectRepo(activeRepo);
+    } catch (e) {
+      error = String(e);
+    }
   }
 
   function handleNewWorkspace() {
@@ -576,7 +598,9 @@
       <RepoSettingsPanel
         repoId={activeRepo.id}
         repoName={activeRepo.display_name}
+        repoPath={activeRepo.path}
         currentProfile={activeRepo.gh_profile ?? null}
+        onRemoveRepo={handleRemoveRepo}
         onClose={() => {
           showSettings = false;
           if (activeRepo) {


### PR DESCRIPTION
## Summary
- Adds a "Remove" button in the repo settings sidebar footer with trash icon
- Shows a confirmation dialog before removing (displays repo name and path)
- Calls existing `remove_repo` backend command and cleans up all frontend state (workspaces, PR status, change counts)
- Falls back to the next available repo or empty state after removal

## Test plan
- [ ] Open settings for a repo, verify "Remove" button appears in the sidebar footer
- [ ] Click Remove, verify confirmation dialog appears with correct repo name/path
- [ ] Click Cancel, verify dialog closes without removing
- [ ] Click Remove in dialog, verify repo is removed and app switches to next repo or empty state
- [ ] Verify workspaces for the removed repo are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)