### PR TITLE
fix: refresh PR status when switching workspaces

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -405,7 +405,8 @@
 
   function selectWorkspace(wsId: string) {
     selectedWsId = wsId;
-    // Don't fetch on switch — use cached values. Refresh happens after agent work.
+    // Refresh PR status in background so it's current when the user lands on the workspace
+    refreshPrStatus(wsId);
   }
 </script>
 


### PR DESCRIPTION
## Summary
- `selectWorkspace()` now calls `refreshPrStatus(wsId)` in the background on every workspace switch
- Previously PR status was only updated on repo open, after agent work, or via 15s polling — switching workspaces used stale cached values
- The call is fire-and-forget with existing error handling, so it won't block the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)