### PR TITLE
feat: display Claude's thinking blocks in chat UI

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -168,6 +168,8 @@ pub enum AgentEvent {
     AssistantMessage {
         text: String,
         tool_uses: Vec<ToolUseInfo>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thinking: Option<String>,
     },
     #[serde(rename = "done")]
     Done,
@@ -204,6 +206,7 @@ fn parse_stream_line(
 
             let mut text_parts = Vec::new();
             let mut tool_uses = Vec::new();
+            let mut thinking_parts = Vec::new();
 
             for block in content {
                 match block.get("type").and_then(|t| t.as_str()) {
@@ -259,13 +262,25 @@ fn parse_stream_line(
                             file_path,
                         });
                     }
+                    Some("thinking") => {
+                        if let Some(t) = block.get("thinking").and_then(|t| t.as_str()) {
+                            if !t.is_empty() {
+                                thinking_parts.push(t.to_string());
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
 
             let text = text_parts.join("\n");
-            if !text.is_empty() || !tool_uses.is_empty() {
-                let _ = on_event.send(AgentEvent::AssistantMessage { text, tool_uses });
+            let thinking = if thinking_parts.is_empty() {
+                None
+            } else {
+                Some(thinking_parts.join("\n"))
+            };
+            if !text.is_empty() || !tool_uses.is_empty() || thinking.is_some() {
+                let _ = on_event.send(AgentEvent::AssistantMessage { text, tool_uses, thinking });
             }
         }
         "result" => {

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -112,7 +112,23 @@
           {/if}
           <div class="assistant-msg">
             {#each msg.chunks as chunk}
-              {#if chunk.type === "text"}
+              {#if chunk.type === "thinking"}
+                <details class="thinking-block">
+                  <summary class="thinking-summary">
+                    <span class="thinking-icon">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 2a7 7 0 0 1 7 7c0 2.38-1.19 4.47-3 5.74V17a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1v-2.26C6.19 13.47 5 11.38 5 9a7 7 0 0 1 7-7z"/>
+                        <line x1="9" y1="21" x2="15" y2="21"/>
+                      </svg>
+                    </span>
+                    <span class="thinking-label">Thinking</span>
+                    <span class="thinking-chevron"></span>
+                  </summary>
+                  <div class="thinking-content">
+                    <p class="thinking-text">{chunk.content}</p>
+                  </div>
+                </details>
+              {:else if chunk.type === "text"}
                 <div class="assistant-card">
                   <p class="assistant-text">{chunk.content}</p>
                 </div>
@@ -319,7 +335,7 @@
     opacity: 0.6;
   }
 
-  /* ── Thinking ──────────────────────────────── */
+  /* ── Thinking indicator (while streaming) ──── */
 
   .thinking {
     font-size: 0.85rem;
@@ -336,6 +352,77 @@
     50% {
       opacity: 0.5;
     }
+  }
+
+  /* ── Thinking block (collapsible) ──────────── */
+
+  .thinking-block {
+    border: 1px solid color-mix(in srgb, var(--accent) 15%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--accent) 4%, var(--bg-card));
+    overflow: hidden;
+  }
+
+  .thinking-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.75rem;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    transition: color 0.15s;
+  }
+
+  .thinking-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .thinking-summary:hover {
+    color: var(--text-secondary);
+  }
+
+  .thinking-icon {
+    display: flex;
+    align-items: center;
+    color: var(--accent);
+    opacity: 0.7;
+  }
+
+  .thinking-label {
+    font-weight: 500;
+    letter-spacing: 0.01em;
+  }
+
+  .thinking-chevron {
+    margin-left: auto;
+    transition: transform 0.2s ease;
+  }
+
+  .thinking-chevron::after {
+    content: "▸";
+    font-size: 0.7rem;
+  }
+
+  .thinking-block[open] .thinking-chevron {
+    transform: rotate(90deg);
+  }
+
+  .thinking-content {
+    padding: 0 0.75rem 0.5rem;
+    border-top: 1px solid color-mix(in srgb, var(--accent) 10%, transparent);
+  }
+
+  .thinking-text {
+    margin: 0.4rem 0 0;
+    font-size: 0.8rem;
+    line-height: 1.55;
+    color: var(--text-dim);
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-style: italic;
   }
 
   /* ── File pills (inline in chat) ─────────────── */

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -35,7 +35,7 @@ export interface ToolUseInfo {
 }
 
 export type AgentEvent =
-  | { type: "assistant_message"; text: string; tool_uses: ToolUseInfo[] }
+  | { type: "assistant_message"; text: string; tool_uses: ToolUseInfo[]; thinking?: string }
   | { type: "done" }
   | { type: "error"; message: string };
 

--- a/src/lib/stores/messages.svelte.ts
+++ b/src/lib/stores/messages.svelte.ts
@@ -5,6 +5,7 @@ import { SvelteMap } from "svelte/reactivity";
 
 export type MessageChunk =
   | { type: "text"; content: string }
+  | { type: "thinking"; content: string }
   | { type: "tool"; name: string; input: string; filePath?: string };
 
 export interface Message {
@@ -90,8 +91,12 @@ export function addAssistantMessage(
   id: string,
   text: string,
   toolUses: { name: string; input: string; filePath?: string }[],
+  thinking?: string,
 ) {
   const chunks: MessageChunk[] = [];
+  if (thinking) {
+    chunks.push({ type: "thinking", content: thinking });
+  }
   if (text) {
     chunks.push({ type: "text", content: text });
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -274,6 +274,7 @@
             crypto.randomUUID(),
             event.text.trim(),
             toolUses,
+            event.thinking,
           );
           if (event.tool_uses.length > 0) {
             diffRefreshTrigger++;


### PR DESCRIPTION
## Summary
- Parse `"thinking"` content blocks from Claude's `stream-json` output (previously silently dropped)
- Add `thinking` field to `AgentEvent::AssistantMessage` and thread it through IPC → store → UI
- Render thinking as collapsible `<details>` elements with lightbulb icon, collapsed by default
- Amber-tinted styling consistent with the app's visual identity

## Test plan
- [ ] Send a message to an agent and verify thinking blocks appear as collapsible pills
- [ ] Click to expand/collapse — check chevron animation and content visibility
- [ ] Verify messages without thinking render unchanged
- [ ] Restart app and confirm thinking persists in saved messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)