### PR TITLE
refactor: move settings button from title bar to sidebar

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { WorkspaceInfo, PrStatus } from "$lib/ipc";
+  import { Settings } from "lucide-svelte";
 
   interface Props {
     workspaces: WorkspaceInfo[];
@@ -7,11 +8,11 @@
     creatingWsId: string | null;
     prStatusMap: Map<string, PrStatus>;
     onSelect: (wsId: string) => void;
-    onNewWorkspace: () => void;
+    onSettings: () => void;
     onRename: (wsId: string, newName: string) => void;
   }
 
-  let { workspaces, selectedWsId, creatingWsId, prStatusMap, onSelect, onNewWorkspace, onRename }: Props =
+  let { workspaces, selectedWsId, creatingWsId, prStatusMap, onSelect, onSettings, onRename }: Props =
     $props();
 
   let activeWorkspaces = $derived(
@@ -86,8 +87,9 @@
       </button>
     {/each}
   </div>
-  <button class="new-ws-btn" onclick={onNewWorkspace} disabled={!!creatingWsId}>
-    + New workspace
+  <button class="settings-btn" onclick={onSettings} title="Repository settings">
+    <Settings size={14} />
+    <span>Settings</span>
   </button>
 </aside>
 
@@ -222,11 +224,15 @@
     min-width: 0;
   }
 
-  .new-ws-btn {
+  .settings-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
     margin: 0.5rem;
     padding: 0.4rem;
     background: transparent;
-    border: 1px dashed var(--border-light);
+    border: 1px solid transparent;
     border-radius: 4px;
     color: var(--text-dim);
     cursor: pointer;
@@ -234,14 +240,8 @@
     font-size: 0.8rem;
   }
 
-  .new-ws-btn:hover:not(:disabled) {
-    color: var(--accent);
-    border-color: var(--accent);
+  .settings-btn:hover {
+    color: var(--text-primary);
     background: var(--bg-hover);
-  }
-
-  .new-ws-btn:disabled {
-    opacity: 0.4;
-    cursor: default;
   }
 </style>

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import type { RepoDetail, WorkspaceInfo, PrStatus } from "$lib/ipc";
-  import { Settings, ExternalLink, Check, X, Loader } from "lucide-svelte";
+  import { Check, X, Loader } from "lucide-svelte";
   import { openUrl } from "@tauri-apps/plugin-opener";
 
   interface Props {
@@ -11,10 +11,9 @@
     prStatus: PrStatus | undefined;
     onSelectRepo: (repo: RepoDetail) => void;
     onAddRepo: () => void;
-    onSettings: () => void;
   }
 
-  let { repos, activeRepo, selectedWs, prStatus, onSelectRepo, onAddRepo, onSettings }: Props =
+  let { repos, activeRepo, selectedWs, prStatus, onSelectRepo, onAddRepo }: Props =
     $props();
 
   function startDrag(e: MouseEvent) {
@@ -83,9 +82,6 @@
         <span class="breadcrumb-base">{activeRepo.default_branch}</span>
       </span>
     {/if}
-    <button class="settings-btn" onclick={onSettings} title="Repository settings">
-      <Settings size={14} />
-    </button>
   </div>
 </header>
 
@@ -222,18 +218,4 @@
     to { transform: rotate(360deg); }
   }
 
-  .settings-btn {
-    background: none;
-    border: none;
-    color: var(--text-dim);
-    cursor: pointer;
-    font-size: 0.9rem;
-    padding: 0.2rem 0.35rem;
-    border-radius: 4px;
-  }
-
-  .settings-btn:hover {
-    color: var(--text-primary);
-    background: var(--border);
-  }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -467,7 +467,6 @@
       prStatus={selectedWsId ? prStatusMap.get(selectedWsId) : undefined}
       onSelectRepo={selectRepo}
       onAddRepo={handleOpenRepo}
-      onSettings={() => (showSettings = true)}
     />
 
     {#if error}
@@ -484,7 +483,7 @@
         {creatingWsId}
         {prStatusMap}
         onSelect={selectWorkspace}
-        onNewWorkspace={handleNewWorkspace}
+        onSettings={() => (showSettings = true)}
         onRename={handleRename}
       />
 


### PR DESCRIPTION
## Summary
- Removed the "New workspace" button from the sidebar (implemented elsewhere)
- Moved the settings button from the title bar into the sidebar footer
- Cleaned up unused imports (`Settings`, `ExternalLink`) from TitleBar

## Test plan
- [ ] Verify settings button appears at bottom of sidebar
- [ ] Verify clicking it opens the settings panel
- [ ] Verify title bar no longer shows a settings icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)