### PR TITLE
fix: show Push button when PR has unpushed local commits

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -905,6 +905,7 @@ pub struct PrStatus {
     pub mergeable: String,       // "mergeable", "conflicting", "unknown"
     pub additions: i64,
     pub deletions: i64,
+    pub ahead_by: i64,         // commits ahead of remote (unpushed)
 }
 
 #[tauri::command]
@@ -943,6 +944,7 @@ pub async fn get_pr_status(
                 mergeable: "unknown".into(),
                 additions: 0,
                 deletions: 0,
+                ahead_by: 0,
             });
         }
 
@@ -981,6 +983,20 @@ pub async fn get_pr_status(
         "none".to_string()
     };
 
+        // Count unpushed commits: how far local branch is ahead of remote
+        let ahead_by = {
+            let rev_output = std::process::Command::new("git")
+                .args(["rev-list", "--count", &format!("origin/{}..{}", branch, branch)])
+                .current_dir(&worktree_path)
+                .output();
+            match rev_output {
+                Ok(o) if o.status.success() => {
+                    String::from_utf8_lossy(&o.stdout).trim().parse::<i64>().unwrap_or(0)
+                }
+                _ => 0,
+            }
+        };
+
         Ok(PrStatus {
             state: pr_state,
             url,
@@ -990,6 +1006,7 @@ pub async fn get_pr_status(
             mergeable,
             additions,
             deletions,
+            ahead_by,
         })
     }).await.map_err(|e| format!("Task failed: {}", e))?
 }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -196,6 +196,7 @@ export interface PrStatus {
   mergeable: "mergeable" | "conflicting" | "unknown";
   additions: number;
   deletions: number;
+  ahead_by: number;
 }
 
 export async function getPrStatus(workspaceId: string): Promise<PrStatus> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -345,6 +345,8 @@
         sendPrompt(wsId, `PR #${pr.number} has merge conflicts with ${baseBranch}.\n\nResolve them:\n1. Run \`git fetch origin ${baseBranch}\`\n2. Run \`git merge origin/${baseBranch}\`\n3. Resolve all conflicts\n4. Commit the merge\n5. Push\n\nIf the conflicts are complex, explain what's conflicting before resolving.`, `Resolving conflicts on PR #${pr.number}`);
       } else if (pr.checks === "failing") {
         sendPrompt(wsId, `PR #${pr.number} has failing checks. Investigate the failures using \`gh pr checks ${pr.number}\`, fix the issues, commit, and push.`, `Fixing checks on PR #${pr.number}`);
+      } else if (pr.ahead_by > 0) {
+        sendPrompt(wsId, `Push local commits to origin. Run \`git push\`. Only say "Pushed successfully" on success. If it fails, explain why.`, `Pushing to PR #${pr.number}`);
       } else {
         sendPrompt(wsId, `Merge PR #${pr.number} using \`gh pr merge ${pr.number} --squash --delete-branch=false\`. Only say "PR #${pr.number} merged successfully" on success. If it fails, explain why.`, `Merging PR #${pr.number}`);
       }
@@ -416,7 +418,8 @@
         prev.number === pr.number &&
         prev.additions === pr.additions &&
         prev.deletions === pr.deletions &&
-        prev.title === pr.title
+        prev.title === pr.title &&
+        prev.ahead_by === pr.ahead_by
       ) {
         return; // No change — skip reactive update
       }
@@ -521,6 +524,8 @@
                   <button class="status-badge checks-fail" onclick={handlePrAction}>Fix issues</button>
                 {:else if prStatusMap.get(selectedWs.id)?.checks === "pending"}
                   <span class="status-badge checks-pending">PR #{prStatusMap.get(selectedWs.id)?.number} · Checks</span>
+                {:else if (prStatusMap.get(selectedWs.id)?.ahead_by ?? 0) > 0}
+                  <button class="status-badge push-needed" onclick={handlePrAction}>Push</button>
                 {:else}
                   <button class="status-badge mergeable" onclick={handlePrAction}>Merge #{prStatusMap.get(selectedWs.id)?.number}</button>
                 {/if}
@@ -861,6 +866,18 @@
     border-color: color-mix(in srgb, var(--diff-del) 40%, transparent);
     background: color-mix(in srgb, var(--diff-del) 7%, transparent);
     text-transform: none;
+  }
+
+  .status-badge.push-needed {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    background: color-mix(in srgb, var(--accent) 7%, transparent);
+    cursor: pointer;
+    text-transform: none;
+  }
+
+  .status-badge.push-needed:hover {
+    filter: brightness(1.2);
   }
 
   .status-badge.mergeable {


### PR DESCRIPTION
## Summary
- When a PR is open with no issues (no conflicts, no failing checks) but the local branch has unpushed commits, the CTA button now shows "Push" instead of "Merge PR"
- Adds `ahead_by` field to `PrStatus` using `git rev-list --count` to detect unpushed commits
- Clicking "Push" sends the agent a prompt to run `git push`

## Test plan
- [ ] Create a workspace, make changes, create a PR
- [ ] Make additional local commits after the PR is created
- [ ] Verify the button shows "Push" instead of "Merge #N"
- [ ] Click Push, verify the agent pushes successfully
- [ ] After push completes, verify the button returns to "Merge #N"

🤖 Generated with [Claude Code](https://claude.com/claude-code)