### PR TITLE
fix: sync sidebar UI immediately on MCP branch rename

### DIFF
--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -72,7 +72,7 @@ fn handle_request(
     let path = parts.get(1).unwrap_or(&"");
 
     let (status, response_body) = match (*method, *path) {
-        ("POST", "/rename-branch") => handle_rename_branch(&body, state),
+        ("POST", "/rename-branch") => handle_rename_branch(&body, state, app),
         ("GET", "/workspace-info") => handle_workspace_info(&request_line, state),
         ("POST", "/notify") => handle_notify(&body, app),
         _ => ("404 Not Found".to_string(), r#"{"error":"not found"}"#.to_string()),
@@ -94,6 +94,7 @@ fn handle_request(
 fn handle_rename_branch(
     body: &[u8],
     state: &Arc<Mutex<AppState>>,
+    app: &AppHandle,
 ) -> (String, String) {
     let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) else {
         return ("400 Bad Request".into(), r#"{"error":"invalid json"}"#.into());
@@ -147,6 +148,11 @@ fn handle_rename_branch(
         ws.branch = new_branch.clone();
         ws.name = new_name.clone();
         let _ = st.save_workspaces();
+    }
+
+    // Emit event so the frontend updates immediately
+    if let Some(ws) = st.workspaces.get(&workspace_id) {
+        let _ = app.emit("workspace-updated", ws.clone());
     }
 
     (

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -243,3 +243,9 @@ export function onAgentStatus(
 ): Promise<UnlistenFn> {
   return listen<AgentStatusEvent>("agent-status", (e) => callback(e.payload));
 }
+
+export function onWorkspaceUpdated(
+  callback: (ws: WorkspaceInfo) => void,
+): Promise<UnlistenFn> {
+  return listen<WorkspaceInfo>("workspace-updated", (e) => callback(e.payload));
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
     sendMessage,
     saveImage,
     onAgentStatus,
+    onWorkspaceUpdated,
     stopAgent,
     renameBranch,
     getRepoSettings,
@@ -67,7 +68,8 @@
   // ── Lifecycle ──────────────────────────────────────────
 
   onMount(() => {
-    let unlistenFn: (() => void) | undefined;
+    let unlistenStatus: (() => void) | undefined;
+    let unlistenWsUpdate: (() => void) | undefined;
 
     (async () => {
       listRepos().then((r) => {
@@ -75,13 +77,20 @@
         if (r.length > 0) selectRepo(r[0]);
       }).catch((e) => { error = String(e); });
 
-      unlistenFn = await onAgentStatus((event) => {
+      unlistenStatus = await onAgentStatus((event) => {
         const ws = workspaces.find((w) => w.id === event.workspace_id);
         if (ws) {
           ws.status = event.status as WorkspaceInfo["status"];
         }
         if (event.status === "waiting") {
           setSending(event.workspace_id, false);
+        }
+      });
+
+      unlistenWsUpdate = await onWorkspaceUpdated((updated) => {
+        const idx = workspaces.findIndex((w) => w.id === updated.id);
+        if (idx >= 0) {
+          workspaces[idx] = updated;
         }
       });
     })();
@@ -129,7 +138,8 @@
     }, 15_000);
 
     return () => {
-      unlistenFn?.();
+      unlistenStatus?.();
+      unlistenWsUpdate?.();
       clearInterval(prPollInterval);
       window.removeEventListener("keydown", handleKeydown);
     };


### PR DESCRIPTION
## Summary
- The MCP `rename-branch` HTTP endpoint updated backend state but never emitted a Tauri event, so the sidebar/titlebar only reflected renames after the agent session ended.
- Added a `workspace-updated` Tauri event emission from the MCP handler and a frontend listener that patches the workspace array in place for immediate UI sync.

## Test plan
- [ ] Trigger a branch rename via MCP (send a chat that causes Claude to call `rename_branch`)
- [ ] Verify the sidebar and title bar update immediately without waiting for the session to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)