### PR TITLE
feat: tint titlebar blue in dev mode

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -47,7 +47,12 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<header class="titlebar" onmousedown={startDrag} ondblclick={handleDoubleClick}>
+<header
+  class="titlebar"
+  class:dev={import.meta.env.DEV}
+  onmousedown={startDrag}
+  ondblclick={handleDoubleClick}
+>
   <div class="titlebar-left">
     <Dropdown bind:this={dropdownRef}>
       {#snippet trigger()}
@@ -124,6 +129,11 @@
     user-select: none;
     cursor: default;
     flex-shrink: 0;
+  }
+
+  .titlebar.dev {
+    background: #191726;
+    border-bottom-color: #252238;
   }
 
   .titlebar-left {


### PR DESCRIPTION
## Summary
- Adds a warm navy (`#191726`) background to the titlebar when running in dev mode (`import.meta.env.DEV`)
- Border color also shifts to `#252238` for cohesion
- Production builds are unaffected — they keep the default `var(--bg-titlebar)`

## Test plan
- [ ] Run `tauri dev` and verify the titlebar has a subtle blue tint
- [ ] Build for production and verify the titlebar is the normal warm dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)