### PR TITLE
fix: restore inline diff rendering for chat-initiated messages

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -375,6 +375,8 @@
             name: t.name,
             input: t.input_preview ?? "",
             filePath: t.file_path,
+            oldString: t.old_string,
+            newString: t.new_string,
           }));
           addAssistantMessage(
             wsId,


### PR DESCRIPTION
## Summary
- PR #20 added inline diff rendering for Edit tool calls but the `handleSend` event handler (normal chat input) was missing the `oldString`/`newString` field mapping — only `sendPrompt` (action buttons) had it
- Adds the two missing fields so Edit tool calls show inline diffs regardless of how the message was sent

## Test plan
- [ ] Send a message that triggers an Edit tool call via the chat input — verify inline diff renders
- [ ] Verify action-button-triggered edits (e.g. "Fix conflicts") still show inline diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)