### PR TITLE
fix: show text descriptions for all tool call types in chat panel

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -255,8 +255,30 @@ fn parse_stream_line(
                                 input.get("pattern").and_then(|p| p.as_str())
                             {
                                 Some(strip(pattern))
+                            } else if let Some(query) =
+                                input.get("query").and_then(|q| q.as_str())
+                            {
+                                Some(strip(query).chars().take(120).collect())
+                            } else if let Some(desc) =
+                                input.get("description").and_then(|d| d.as_str())
+                            {
+                                Some(strip(desc).chars().take(120).collect())
+                            } else if let Some(skill) =
+                                input.get("skill").and_then(|s| s.as_str())
+                            {
+                                Some(strip(skill))
+                            } else if let Some(url) =
+                                input.get("url").and_then(|u| u.as_str())
+                            {
+                                Some(url.chars().take(120).collect())
                             } else {
-                                None
+                                // Fallback: use first short string value from input
+                                input.as_object().and_then(|obj| {
+                                    obj.values()
+                                        .filter_map(|v| v.as_str())
+                                        .find(|s| !s.is_empty() && s.len() < 200)
+                                        .map(|s| strip(s).chars().take(120).collect())
+                                })
                             }
                         });
 

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -232,7 +232,7 @@
                     <span class="tool-icon">
                       <ToolIcon size={13} strokeWidth={2} />
                     </span>
-                    {#if chunk.input}{chunk.input}{/if}
+                    {chunk.input || chunk.name}
                   </span>
                 </div>
               {/if}


### PR DESCRIPTION
## Summary
- Tool calls like ToolSearch, Agent, Skill, and WebFetch only showed a gear icon with no text in the chat panel
- Added `input_preview` extraction for `query`, `description`, `skill`, and `url` input fields in Rust, plus a generic fallback for unknown tools
- Frontend now falls back to showing the tool name when no preview text is available

## Test plan
- [ ] Trigger tool calls for ToolSearch, Agent, Skill, WebFetch and verify text appears next to icons
- [ ] Verify existing tools (Read, Bash, Grep, Glob, Edit) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)