### PR TITLE
fix: disable Push & Create PR button while agent is running

### DIFF
--- a/src/lib/components/DiffViewer.svelte
+++ b/src/lib/components/DiffViewer.svelte
@@ -6,9 +6,10 @@
     refreshTrigger?: number;
     prState?: string;
     onCreatePr?: () => void;
+    disabled?: boolean;
   }
 
-  let { workspaceId, refreshTrigger = 0, prState, onCreatePr }: Props = $props();
+  let { workspaceId, refreshTrigger = 0, prState, onCreatePr, disabled = false }: Props = $props();
 
   let files = $state<ChangedFile[]>([]);
   let selectedFile = $state<string | null>(null);
@@ -129,7 +130,7 @@
           <button class="refresh-btn-sm" onclick={loadFiles} title="Refresh">↻</button>
         </div>
         {#if onCreatePr && (!prState || prState === "none") && files.length > 0}
-          <button class="create-pr-btn" onclick={onCreatePr}>
+          <button class="create-pr-btn" onclick={onCreatePr} disabled={disabled}>
             Push & Create PR
           </button>
         {/if}
@@ -272,8 +273,13 @@
     text-align: center;
   }
 
-  .create-pr-btn:hover {
+  .create-pr-btn:hover:not(:disabled) {
     background: color-mix(in srgb, var(--accent) 10%, transparent);
+  }
+
+  .create-pr-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
   }
 
   .file-list {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -672,6 +672,7 @@
                   refreshTrigger={diffRefreshTrigger}
                   prState={prStatusMap.get(selectedWs.id)?.state}
                   onCreatePr={handlePrAction}
+                  disabled={selectedWs.status === "running"}
                 />
               </div>
             {/if}


### PR DESCRIPTION
## Summary
- Adds a `disabled` prop to `DiffViewer` that grays out the "Push & Create PR" button when the workspace agent is running
- The tab bar PR action buttons (Conflicts, Fix issues, Push, Merge) were already hidden during running state via the existing `{#if}` chain

## Test plan
- [ ] Start an agent in a workspace, switch to Diff tab — button should appear grayed out and unclickable
- [ ] Wait for agent to finish — button should re-enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)