### PR TITLE
fix: resolve MCP server path from Korlap source, not user repo

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -823,27 +823,16 @@ pub fn rename_branch(
         return Err("Cannot rename an archived workspace".into());
     }
 
-    let old_branch = ws.branch.clone();
-    // No prefix — user provides the full branch name (e.g. feat/fix-auth)
-    let new_branch = new_name.clone();
     let worktree_path = ws.worktree_path.clone();
+    let fallback_branch = ws.branch.clone();
 
-    let output = std::process::Command::new("git")
-        .args(["branch", "-m", &old_branch, &new_branch])
-        .current_dir(&worktree_path)
-        .output()
-        .map_err(|e| format!("Failed to run git branch -m: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git branch rename failed: {}", stderr.trim()));
-    }
+    crate::state::rename_git_branch(&worktree_path, &new_name, &fallback_branch)?;
 
     let ws = st
         .workspaces
         .get_mut(&workspace_id)
         .ok_or("Workspace not found")?;
-    ws.branch = new_branch;
+    ws.branch = new_name.clone();
     ws.name = new_name;
     let ws_clone = ws.clone();
     st.save_workspaces()?;
@@ -1580,8 +1569,22 @@ pub fn send_message(
         (st.mcp_api_port, st.data_dir.clone())
     };
 
-    let mcp_server_path = repo_path.join("src-mcp").join("server.ts");
-    let mcp_config_path = if mcp_server_path.exists() {
+    // Resolve MCP server script: dev source tree first (compile-time, no I/O), then bundled.
+    let mcp_dir = data_dir.join("mcp");
+    let mcp_server_path = {
+        // Dev mode: resolve from CARGO_MANIFEST_DIR (src-tauri/../src-mcp/server.ts)
+        let dev_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("src-mcp")
+            .join("server.ts");
+        if dev_path.exists() {
+            Some(dev_path)
+        } else {
+            let bundled = mcp_dir.join("server.ts");
+            if bundled.exists() { Some(bundled) } else { None }
+        }
+    };
+    let mcp_config_path = if let Some(ref mcp_server_path) = mcp_server_path {
         let mcp_config = serde_json::json!({
             "mcpServers": {
                 "korlap": {
@@ -1595,9 +1598,8 @@ pub fn send_message(
                 }
             }
         });
-        let config_dir = data_dir.join("mcp");
-        let _ = std::fs::create_dir_all(&config_dir);
-        let config_path = config_dir.join(format!("{}.json", workspace_id));
+        let _ = std::fs::create_dir_all(&mcp_dir);
+        let config_path = mcp_dir.join(format!("{}.json", workspace_id));
         let _ = std::fs::write(
             &config_path,
             serde_json::to_string(&mcp_config).unwrap_or_default(),

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -124,28 +124,15 @@ fn handle_rename_branch(
         return ("400 Bad Request".into(), r#"{"error":"cannot rename archived workspace"}"#.into());
     }
 
-    let old_branch = ws.branch.clone();
-    let new_branch = new_name.clone();
     let worktree_path = ws.worktree_path.clone();
+    let fallback_branch = ws.branch.clone();
 
-    let output = std::process::Command::new("git")
-        .args(["branch", "-m", &old_branch, &new_branch])
-        .current_dir(&worktree_path)
-        .output();
-
-    match output {
-        Ok(o) if o.status.success() => {}
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            return ("500 Internal Server Error".into(), format!(r#"{{"error":"git branch -m failed: {}"}}"#, stderr.trim()));
-        }
-        Err(e) => {
-            return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e));
-        }
+    if let Err(e) = crate::state::rename_git_branch(&worktree_path, &new_name, &fallback_branch) {
+        return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e));
     }
 
     if let Some(ws) = st.workspaces.get_mut(&workspace_id) {
-        ws.branch = new_branch.clone();
+        ws.branch = new_name.clone();
         ws.name = new_name.clone();
         let _ = st.save_workspaces();
     }
@@ -157,7 +144,7 @@ fn handle_rename_branch(
 
     (
         "200 OK".into(),
-        format!(r#"{{"ok":true,"branch":"{}","name":"{}"}}"#, new_branch, new_name),
+        format!(r#"{{"ok":true,"branch":"{}","name":"{}"}}"#, new_name, new_name),
     )
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -186,3 +186,34 @@ impl AppState {
         Ok(())
     }
 }
+
+/// Rename a worktree's branch, detecting the actual current branch from git
+/// rather than trusting stored metadata (the agent may have already renamed
+/// it via a bash command). No-ops if the branch is already at the target name.
+pub fn rename_git_branch(worktree_path: &Path, new_branch: &str, fallback_branch: &str) -> Result<(), String> {
+    let current_branch = match std::process::Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(worktree_path)
+        .output()
+    {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => fallback_branch.to_string(),
+    };
+
+    if current_branch == new_branch {
+        return Ok(());
+    }
+
+    let output = std::process::Command::new("git")
+        .args(["branch", "-m", &current_branch, new_branch])
+        .current_dir(worktree_path)
+        .output()
+        .map_err(|e| format!("Failed to run git branch -m: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git branch rename failed: {}", stderr.trim()));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- MCP server script was looked up inside the user's managed repo, so `rename_branch` MCP tool was unavailable for non-Korlap repos — the agent fell back to bare `git branch -m` which renamed the branch but never updated workspace metadata or emitted the UI event
- Now resolves MCP server from `CARGO_MANIFEST_DIR` (dev) or bundled data dir (prod)
- Extracted shared `rename_git_branch()` helper that detects the actual current branch via `git branch --show-current`, making rename idempotent when the agent already renamed via bash

## Test plan
- [ ] Open a non-Korlap repo, create a workspace, send a message — verify the agent has access to `rename_branch` MCP tool
- [ ] Verify branch rename updates sidebar name and title bar breadcrumb immediately
- [ ] Verify rename still works when agent runs `git branch -m` via bash before calling MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)