### PR TITLE
fix: allow branch rename without permission in plan mode

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1777,6 +1777,9 @@ pub fn send_message(
     // Permission mode: plan mode uses --permission-mode plan, otherwise bypass all
     if plan_mode {
         cmd.args(["--permission-mode", "plan"]);
+        // Allow rename_branch to execute without permission in plan mode —
+        // branch naming is a side-effect-free housekeeping action, not a code change
+        cmd.args(["--allowedTools", "mcp__korlap__rename_branch"]);
     } else {
         cmd.arg("--dangerously-skip-permissions");
     }


### PR DESCRIPTION
## Summary
- Plan mode (`--permission-mode plan`) gates all tool calls, which blocks `rename_branch` from executing automatically
- Adds `--allowedTools mcp__korlap__rename_branch` when spawning Claude in plan mode so branch naming happens immediately without user approval
- Branch renaming is a side-effect-free housekeeping action that shouldn't require permission

## Test plan
- [ ] Create a workspace with plan mode enabled, send a message, verify branch rename happens without waiting for permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)