### PR TITLE
refactor: clean up status indicators and move PR button to tab bar

### DIFF
--- a/src/lib/components/DiffViewer.svelte
+++ b/src/lib/components/DiffViewer.svelte
@@ -4,12 +4,9 @@
   interface Props {
     workspaceId: string;
     refreshTrigger?: number;
-    prState?: string;
-    onCreatePr?: () => void;
-    disabled?: boolean;
   }
 
-  let { workspaceId, refreshTrigger = 0, prState, onCreatePr, disabled = false }: Props = $props();
+  let { workspaceId, refreshTrigger = 0 }: Props = $props();
 
   let files = $state<ChangedFile[]>([]);
   let selectedFile = $state<string | null>(null);
@@ -129,11 +126,6 @@
           </span>
           <button class="refresh-btn-sm" onclick={loadFiles} title="Refresh">↻</button>
         </div>
-        {#if onCreatePr && (!prState || prState === "none") && files.length > 0}
-          <button class="create-pr-btn" onclick={onCreatePr} disabled={disabled}>
-            Push & Create PR
-          </button>
-        {/if}
         <div class="file-list">
           {#each files as file}
             <button
@@ -257,29 +249,6 @@
 
   .refresh-btn-sm:hover {
     color: var(--text-primary);
-  }
-
-  .create-pr-btn {
-    margin: 0.4rem 0.5rem;
-    padding: 0.35rem 0;
-    background: transparent;
-    border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
-    border-radius: 5px;
-    color: var(--accent);
-    cursor: pointer;
-    font-family: inherit;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-align: center;
-  }
-
-  .create-pr-btn:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--accent) 10%, transparent);
-  }
-
-  .create-pr-btn:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
   }
 
   .file-list {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -129,7 +129,7 @@
               {:else}
                 <span class="ws-name" class:creating-name={ws.id === creatingWsId}>{ws.name}</span>
                 {#if ws.id !== creatingWsId && ws.status === "running"}
-                  <span class="ws-status">running</span>
+                  <span class="ws-spinner"></span>
                 {/if}
               {/if}
             </button>
@@ -351,10 +351,19 @@
     }
   }
 
-  .ws-status {
-    font-size: 0.65rem;
-    color: var(--accent);
+  .ws-spinner {
+    width: 12px;
+    height: 12px;
     margin-left: auto;
+    flex-shrink: 0;
+    border: 1.5px solid color-mix(in srgb, var(--accent) 25%, transparent);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
   }
 
   .ws-name {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -645,9 +645,7 @@
               {/each}
             </div>
             <div class="tab-bar-right">
-              {#if selectedWs.status === "running"}
-                <span class="status-badge running">Running</span>
-              {:else if prStatusMap.get(selectedWs.id)?.state === "open"}
+              {#if prStatusMap.get(selectedWs.id)?.state === "open"}
                 {#if prStatusMap.get(selectedWs.id)?.mergeable === "conflicting"}
                   <button class="status-badge conflicts" onclick={handlePrAction}>Conflicts</button>
                 {:else if prStatusMap.get(selectedWs.id)?.checks === "failing"}
@@ -661,8 +659,11 @@
                 {/if}
               {:else if prStatusMap.get(selectedWs.id)?.state === "merged"}
                 <span class="status-badge merged">Done</span>
-              {:else if selectedWs.status === "waiting"}
-                <span class="status-badge waiting">Ready</span>
+              {:else}
+                {@const cc = changeCounts.get(selectedWs.id)}
+                {#if cc && (cc.additions > 0 || cc.deletions > 0)}
+                  <button class="status-badge create-pr" onclick={handlePrAction} disabled={selectedWs.status === "running"}>Push & Create PR</button>
+                {/if}
               {/if}
             </div>
           </div>
@@ -694,9 +695,6 @@
                 <DiffViewer
                   workspaceId={selectedWs.id}
                   refreshTrigger={diffRefreshTrigger}
-                  prState={prStatusMap.get(selectedWs.id)?.state}
-                  onCreatePr={handlePrAction}
-                  disabled={selectedWs.status === "running"}
                 />
               </div>
             {/if}
@@ -964,18 +962,6 @@
     border: 1px solid;
   }
 
-  .status-badge.running {
-    color: var(--accent);
-    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-    background: color-mix(in srgb, var(--accent) 7%, transparent);
-    animation: badge-pulse 2s ease-in-out infinite;
-  }
-
-  .status-badge.waiting {
-    color: var(--status-ok);
-    border-color: color-mix(in srgb, var(--status-ok) 40%, transparent);
-  }
-
   .status-badge.merged {
     color: var(--text-dim);
     border-color: var(--border-light);
@@ -1033,8 +1019,13 @@
     text-transform: none;
   }
 
-  .status-badge.create-pr:hover {
+  .status-badge.create-pr:hover:not(:disabled) {
     filter: brightness(1.2);
+  }
+
+  .status-badge.create-pr:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
   }
 
   .status-badge.checks-fail {


### PR DESCRIPTION
## Summary
- Remove redundant RUNNING/READY badges from tab bar top-right (sidebar dot indicators already convey workspace status)
- Replace sidebar "running" text label with a spinning amber indicator
- Move "Push & Create PR" button from DiffViewer file sidebar into the tab-bar-right area, styled consistently with other PR action badges (Merge, Push, Conflicts, etc.)
- Clean up dead CSS and unused DiffViewer props

## Test plan
- [ ] Verify no RUNNING/READY badge appears in tab bar top-right
- [ ] Verify sidebar shows spinning indicator for running workspaces
- [ ] Verify "Push & Create PR" button appears in tab bar when there are uncommitted diffs and no existing PR
- [ ] Verify button is disabled while agent is running
- [ ] Verify PR action badges (Merge, Push, Conflicts, etc.) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)