### PR TITLE
feat: render assistant messages as markdown with syntax highlighting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,11 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "devicon": "^2.17.0",
+        "dompurify": "^3.3.3",
+        "highlight.js": "^11.11.1",
         "lucide-svelte": "^0.577.0",
+        "marked": "^17.0.4",
+        "marked-highlight": "^2.2.3",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -20,6 +24,7 @@
         "@sveltejs/kit": "^2.9.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tauri-apps/cli": "^2",
+        "@types/dompurify": "^3.2.0",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "typescript": "~5.6.2",
@@ -192,6 +197,8 @@
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
+    "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
@@ -247,6 +254,8 @@
     "devalue": ["devalue@5.6.4", "", {}, "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA=="],
 
     "devicon": ["devicon@2.17.0", "", {}, "sha512-2nKUdjobJlmRSaCHa50PGsVq0VDURnq9gVzQoJggsM/NKN0tLhC/Uq2zmy2pH36Q/1q3gvYwp/GjTgv/R0Ysbg=="],
+
+    "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -304,6 +313,8 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
     "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -335,6 +346,10 @@
     "lucide-svelte": ["lucide-svelte@0.577.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-0i88o57KsaHWnc80J57fY99CWzlZsSdtH5kKjLUJa7z8dum/9/AbINNLzJ7NiRFUdOgMnfAmJt8jFbW2zeC5qQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@17.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ=="],
+
+    "marked-highlight": ["marked-highlight@2.2.3", "", { "peerDependencies": { "marked": ">=4 <18" } }, "sha512-FCfZRxW/msZAiasCML4isYpxyQWKEEx44vOgdn5Kloae+Qc3q4XR7WjpKKf8oMLk7JP9ZCRd2vhtclJFdwxlWQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "devicon": "^2.17.0",
+    "dompurify": "^3.3.3",
+    "highlight.js": "^11.11.1",
     "lucide-svelte": "^0.577.0",
+    "marked": "^17.0.4",
+    "marked-highlight": "^2.2.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -30,6 +34,7 @@
     "@sveltejs/kit": "^2.9.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tauri-apps/cli": "^2",
+    "@types/dompurify": "^3.2.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "typescript": "~5.6.2",

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -2,6 +2,7 @@
   import { messagesByWorkspace, sendingByWorkspace, type Message, type MessageChunk, type MessageMention } from "$lib/stores/messages.svelte";
   import { searchWorkspaceFiles, type FileSearchResult } from "$lib/ipc";
   import { FileText, Pencil, FilePlus, Terminal, FolderSearch, TextSearch, Bot, Globe, Zap, Settings, Lightbulb, BookOpen, Play, ArrowUp, Square } from "lucide-svelte";
+  import { renderMarkdown } from "$lib/markdown";
   import MentionInput, { type Mention, type MentionInputValue, type MentionInputApi } from "./MentionInput.svelte";
   import MentionAutocomplete, { type MentionAutocompleteApi } from "./MentionAutocomplete.svelte";
 
@@ -329,7 +330,7 @@
                 </details>
               {:else if chunk.type === "text"}
                 <div class="assistant-card">
-                  <p class="assistant-text">{chunk.content}</p>
+                  <div class="assistant-text markdown-body">{@html renderMarkdown(chunk.content)}</div>
                 </div>
               {:else if chunk.type === "tool" && chunk.oldString != null && chunk.newString != null}
                 {@const diffKey = `${msg.id}:${ci}`}
@@ -620,8 +621,144 @@
     font-size: 0.85rem;
     line-height: 1.55;
     color: var(--text-primary);
-    white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  /* ── Markdown body (rendered assistant text) ─── */
+
+  .assistant-text.markdown-body :global(h1),
+  .assistant-text.markdown-body :global(h2),
+  .assistant-text.markdown-body :global(h3),
+  .assistant-text.markdown-body :global(h4) {
+    margin: 0.6rem 0 0.3rem;
+    color: var(--text-bright);
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  .assistant-text.markdown-body :global(h1) { font-size: 1.1rem; }
+  .assistant-text.markdown-body :global(h2) { font-size: 1rem; }
+  .assistant-text.markdown-body :global(h3) { font-size: 0.92rem; }
+  .assistant-text.markdown-body :global(h4) { font-size: 0.85rem; }
+
+  .assistant-text.markdown-body :global(p) {
+    margin: 0.35rem 0;
+    line-height: 1.55;
+  }
+
+  .assistant-text.markdown-body :global(> p:first-child) {
+    margin-top: 0;
+  }
+
+  .assistant-text.markdown-body :global(> p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .assistant-text.markdown-body :global(ul),
+  .assistant-text.markdown-body :global(ol) {
+    margin: 0.3rem 0;
+    padding-left: 1.5rem;
+  }
+
+  .assistant-text.markdown-body :global(li) {
+    margin: 0.15rem 0;
+    line-height: 1.5;
+  }
+
+  .assistant-text.markdown-body :global(li > p) {
+    margin: 0.1rem 0;
+  }
+
+  .assistant-text.markdown-body :global(strong) {
+    color: var(--text-bright);
+    font-weight: 600;
+  }
+
+  .assistant-text.markdown-body :global(em) {
+    font-style: italic;
+    color: var(--text-primary);
+  }
+
+  .assistant-text.markdown-body :global(a) {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .assistant-text.markdown-body :global(a:hover) {
+    text-decoration: underline;
+  }
+
+  /* Inline code */
+  .assistant-text.markdown-body :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    background: var(--bg-active);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0.1rem 0.35rem;
+    color: var(--text-bright);
+  }
+
+  /* Code blocks */
+  .assistant-text.markdown-body :global(pre) {
+    margin: 0.4rem 0;
+    padding: 0.6rem 0.75rem;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow-x: auto;
+    line-height: 1.5;
+  }
+
+  .assistant-text.markdown-body :global(pre code) {
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    font-size: 0.78rem;
+    color: var(--text-primary);
+  }
+
+  /* Tables */
+  .assistant-text.markdown-body :global(table) {
+    border-collapse: collapse;
+    margin: 0.4rem 0;
+    font-size: 0.8rem;
+    width: 100%;
+  }
+
+  .assistant-text.markdown-body :global(th) {
+    background: var(--bg-active);
+    color: var(--text-bright);
+    font-weight: 600;
+    text-align: left;
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--border);
+  }
+
+  .assistant-text.markdown-body :global(td) {
+    padding: 0.3rem 0.6rem;
+    border: 1px solid var(--border);
+  }
+
+  /* Blockquotes */
+  .assistant-text.markdown-body :global(blockquote) {
+    margin: 0.4rem 0;
+    padding: 0.2rem 0.75rem;
+    border-left: 3px solid var(--accent);
+    color: var(--text-secondary);
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+  }
+
+  .assistant-text.markdown-body :global(blockquote p) {
+    margin: 0.2rem 0;
+  }
+
+  /* Horizontal rules */
+  .assistant-text.markdown-body :global(hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0.6rem 0;
   }
 
   /* ── Tool use pills ────────────────────────── */

--- a/src/lib/hljs-korlap.css
+++ b/src/lib/hljs-korlap.css
@@ -1,0 +1,60 @@
+/* highlight.js custom theme for Korlap warm dark palette */
+.hljs {
+  color: var(--text-primary);
+  background: var(--bg-sidebar);
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-built_in,
+.hljs-name,
+.hljs-tag {
+  color: #c8a97e;
+}
+
+.hljs-string,
+.hljs-title,
+.hljs-section,
+.hljs-attribute,
+.hljs-literal,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type {
+  color: #7e9e6b;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #6a6050;
+}
+
+.hljs-number,
+.hljs-regexp,
+.hljs-link,
+.hljs-selector-id,
+.hljs-symbol,
+.hljs-bullet {
+  color: #c87e7e;
+}
+
+.hljs-meta {
+  color: #8a7e6a;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-addition {
+  color: #7e9e6b;
+  background: var(--diff-add-bg);
+}
+
+.hljs-deletion {
+  color: #c87e7e;
+  background: var(--diff-del-bg);
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,90 @@
+import { Marked } from "marked";
+import { markedHighlight } from "marked-highlight";
+import hljs from "highlight.js/lib/core";
+import DOMPurify from "dompurify";
+import "./hljs-korlap.css";
+
+// Register common languages individually to keep bundle small
+import javascript from "highlight.js/lib/languages/javascript";
+import typescript from "highlight.js/lib/languages/typescript";
+import python from "highlight.js/lib/languages/python";
+import rust from "highlight.js/lib/languages/rust";
+import bash from "highlight.js/lib/languages/bash";
+import json from "highlight.js/lib/languages/json";
+import css from "highlight.js/lib/languages/css";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+import markdown from "highlight.js/lib/languages/markdown";
+import sql from "highlight.js/lib/languages/sql";
+import go from "highlight.js/lib/languages/go";
+import java from "highlight.js/lib/languages/java";
+import swift from "highlight.js/lib/languages/swift";
+import diff from "highlight.js/lib/languages/diff";
+import toml from "highlight.js/lib/languages/ini";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import ruby from "highlight.js/lib/languages/ruby";
+import c from "highlight.js/lib/languages/c";
+import cpp from "highlight.js/lib/languages/cpp";
+
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("js", javascript);
+hljs.registerLanguage("jsx", javascript);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("ts", typescript);
+hljs.registerLanguage("tsx", typescript);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("py", python);
+hljs.registerLanguage("rust", rust);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("sh", bash);
+hljs.registerLanguage("shell", bash);
+hljs.registerLanguage("zsh", bash);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("html", xml);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("svg", xml);
+hljs.registerLanguage("svelte", xml);
+hljs.registerLanguage("yaml", yaml);
+hljs.registerLanguage("yml", yaml);
+hljs.registerLanguage("markdown", markdown);
+hljs.registerLanguage("md", markdown);
+hljs.registerLanguage("sql", sql);
+hljs.registerLanguage("go", go);
+hljs.registerLanguage("java", java);
+hljs.registerLanguage("swift", swift);
+hljs.registerLanguage("diff", diff);
+hljs.registerLanguage("toml", toml);
+hljs.registerLanguage("ini", toml);
+hljs.registerLanguage("kotlin", kotlin);
+hljs.registerLanguage("kt", kotlin);
+hljs.registerLanguage("ruby", ruby);
+hljs.registerLanguage("rb", ruby);
+hljs.registerLanguage("c", c);
+hljs.registerLanguage("cpp", cpp);
+
+const marked = new Marked(
+  markedHighlight({
+    langPrefix: "hljs language-",
+    highlight(code: string, lang: string) {
+      if (lang && hljs.getLanguage(lang)) {
+        return hljs.highlight(code, { language: lang }).value;
+      }
+      return hljs.highlightAuto(code).value;
+    },
+  }),
+);
+
+marked.setOptions({
+  gfm: true,
+  breaks: false,
+});
+
+/**
+ * Render a markdown string to sanitized HTML.
+ * Synchronous — safe to call inline in Svelte templates.
+ */
+export function renderMarkdown(raw: string): string {
+  const html = marked.parse(raw) as string;
+  return DOMPurify.sanitize(html);
+}


### PR DESCRIPTION
## Summary
- Add `marked` + `marked-highlight` + `highlight.js` + `DOMPurify` for markdown rendering
- All assistant text chunks now render as rich markdown (headings, lists, code blocks, tables, blockquotes, inline code, links)
- Code blocks get syntax highlighting via a custom hljs theme matching the warm dark palette
- New files: `src/lib/markdown.ts` (rendering utility), `src/lib/hljs-korlap.css` (custom theme)

## Test plan
- [ ] Send a message and verify headings, bold, italic, lists render correctly
- [ ] Verify fenced code blocks have syntax highlighting with warm palette colors
- [ ] Verify inline code, tables, blockquotes, and links render correctly
- [ ] Verify no layout breakage in existing non-markdown messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)