### PR TITLE
fix: allow WebSearch and WebFetch in plan mode

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1770,7 +1770,7 @@ pub fn send_message(
         cmd.args(["--permission-mode", "plan"]);
         // Allow rename_branch to execute without permission in plan mode —
         // branch naming is a side-effect-free housekeeping action, not a code change
-        cmd.args(["--allowedTools", "mcp__korlap__rename_branch"]);
+        cmd.args(["--allowedTools", "mcp__korlap__rename_branch,WebSearch,WebFetch"]);
     } else {
         cmd.arg("--dangerously-skip-permissions");
     }


### PR DESCRIPTION
## Summary
- Plan mode's `--allowedTools` whitelist only included `mcp__korlap__rename_branch`, so agents got "permission denied" when trying to use WebSearch/WebFetch during planning
- Added both tools to the whitelist since they're read-only and safe for plan mode

## Test plan
- [ ] Run a workspace in plan mode and verify the agent can use WebSearch/WebFetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)