### PR TITLE
feat: add configurable PR message in Agent settings

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -42,6 +42,8 @@ pub struct RepoSettings {
     pub run_script: String,
     #[serde(default, alias = "archive_script")]
     pub remove_script: String,
+    #[serde(default)]
+    pub pr_message: String,
 }
 
 pub struct TerminalHandle {

--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -26,6 +26,7 @@
     setup_script: "",
     run_script: "",
     remove_script: "",
+    pr_message: "",
   });
   let saveStatus = $state<"idle" | "saving" | "saved">("idle");
   let saveTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -178,8 +179,38 @@
     {:else if activeSection === "agent"}
       <div class="section-header">
         <h1>Agent</h1>
+        <span class="autosave-status" class:visible={saveStatus !== "idle"}>
+          {saveStatus === "saving" ? "Saving..." : "Saved"}
+        </span>
       </div>
-      <p class="coming-soon">Model selection, permission mode, and system prompt customization.</p>
+
+      <div class="setting-block">
+        <div class="setting-meta">
+          <span class="setting-name">Create PR message</span>
+          <span class="setting-desc">Custom prompt sent to the agent when creating a pull request. Leave empty to use the default.</span>
+        </div>
+        <textarea
+          class="pr-message-field"
+          bind:value={settings.pr_message}
+          oninput={scheduleAutosave}
+          placeholder={`The user likes the current state of the code.\n\nThere are {{file_count}} uncommitted changes.\nThe current branch is {{branch}}.\nThe target branch is origin/{{base_branch}}.\n\nFollow these steps to create a PR:\n- Run \`git diff\` to review uncommitted changes\n- Commit them with a descriptive message\n- Push to origin\n- Use \`gh pr create --base {{base_branch}}\` to create a PR. Keep the title under 80 characters.\n\nIf any step fails, explain the issue.`}
+          rows="14"
+          spellcheck="false"
+        ></textarea>
+      </div>
+
+      <div class="env-hint">
+        <span class="env-hint-title">Available template variables</span>
+        <div class="env-vars">
+          <code>{"{{branch}}"}</code>
+          <code>{"{{base_branch}}"}</code>
+          <code>{"{{file_count}}"}</code>
+          <code>{"{{pr_template}}"}</code>
+        </div>
+        <p class="template-var-hint">
+          <code>{"{{pr_template}}"}</code> inserts the repo's PR template (from <code>.github/pull_request_template.md</code>) if one exists.
+        </p>
+      </div>
 
     {:else if activeSection === "git"}
       <div class="section-header">
@@ -482,6 +513,45 @@
     padding: 0.1rem 0.35rem;
     border-radius: 3px;
     font-size: 0.78rem;
+  }
+
+  .pr-message-field {
+    width: 100%;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    padding: 0.6rem 0.65rem;
+    resize: vertical;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .pr-message-field::placeholder {
+    color: var(--text-muted);
+  }
+
+  .pr-message-field:focus {
+    border-color: var(--border-light);
+  }
+
+  .template-var-hint {
+    margin-top: 0.5rem;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+  }
+
+  .template-var-hint code {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
   }
 
   .profile-list {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -287,6 +287,7 @@ export interface RepoSettings {
   setup_script: string;
   run_script: string;
   remove_script: string;
+  pr_message: string;
 }
 
 export async function getRepoSettings(repoId: string): Promise<RepoSettings> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -500,19 +500,34 @@
       const baseBranch = activeRepo.default_branch;
       const template = await getPrTemplate(activeRepo.id).catch(() => "");
 
-      let prompt = `Create a pull request.\n\n`;
-      prompt += `There are ${files.length} uncommitted changes.\n`;
-      prompt += `The current branch is ${selectedWs.branch}.\n`;
-      prompt += `The target branch is origin/${baseBranch}.\n\n`;
-      prompt += `Follow these steps:\n`;
-      prompt += `1. Run \`git diff\` to review uncommitted changes\n`;
-      prompt += `2. Commit them with a descriptive message\n`;
-      prompt += `3. Push to origin\n`;
-      prompt += `4. Use \`gh pr create --base ${baseBranch}\` to create a PR. Keep the title under 80 characters. Keep the description under five sentences unless there's a template.\n\n`;
-      prompt += `If any step fails, explain the issue.\n`;
+      let prompt: string;
+      const customMsg = repoSettings?.pr_message?.trim();
 
-      if (template) {
-        prompt += `\n## PR Description Template\n\nThis repo has a PR template. Use it:\n\n\`\`\`markdown\n${template}\n\`\`\`\n`;
+      if (customMsg) {
+        // Interpolate template variables in custom PR message
+        prompt = customMsg
+          .replace(/\{\{branch\}\}/g, selectedWs.branch)
+          .replace(/\{\{base_branch\}\}/g, baseBranch)
+          .replace(/\{\{file_count\}\}/g, String(files.length))
+          .replace(/\{\{pr_template\}\}/g, template
+            ? `\n## PR Description Template\n\nThis workspace has a PR template. Use it:\n\n\`\`\`markdown\n${template}\n\`\`\`\n`
+            : "");
+      } else {
+        // Default prompt
+        prompt = `Create a pull request.\n\n`;
+        prompt += `There are ${files.length} uncommitted changes.\n`;
+        prompt += `The current branch is ${selectedWs.branch}.\n`;
+        prompt += `The target branch is origin/${baseBranch}.\n\n`;
+        prompt += `Follow these steps:\n`;
+        prompt += `1. Run \`git diff\` to review uncommitted changes\n`;
+        prompt += `2. Commit them with a descriptive message\n`;
+        prompt += `3. Push to origin\n`;
+        prompt += `4. Use \`gh pr create --base ${baseBranch}\` to create a PR. Keep the title under 80 characters. Keep the description under five sentences unless there's a template.\n\n`;
+        prompt += `If any step fails, explain the issue.\n`;
+
+        if (template) {
+          prompt += `\n## PR Description Template\n\nThis repo has a PR template. Use it:\n\n\`\`\`markdown\n${template}\n\`\`\`\n`;
+        }
       }
 
       activeTab = "chat";


### PR DESCRIPTION
## Summary
- Adds a "Create PR message" textarea to the Agent section of repo settings, replacing the "coming soon" placeholder
- Supports template variables (`{{branch}}`, `{{base_branch}}`, `{{file_count}}`, `{{pr_template}}`) that get interpolated at runtime
- Falls back to the existing default prompt when the field is empty
- Persisted via the existing `RepoSettings` / `repo_settings.json` pipeline with autosave

## Test plan
- [ ] Open repo settings → Agent tab → verify textarea renders with placeholder showing default format
- [ ] Type a custom PR message with template variables, verify autosave triggers
- [ ] Click PR button on a workspace → verify custom message is sent with variables interpolated
- [ ] Clear the textarea → verify the default PR prompt is used instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)