### PR TITLE
fix: always show all sidebar groups even when empty

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -54,11 +54,11 @@
       }
     }
 
-    const result: { key: GroupKey; label: string; items: WorkspaceInfo[] }[] = [];
-    if (ready.length) result.push({ key: "ready", label: "Ready", items: ready });
-    if (review.length) result.push({ key: "review", label: "Review", items: review });
-    if (done.length) result.push({ key: "done", label: "Done", items: done });
-    return result;
+    return [
+      { key: "ready" as GroupKey, label: "Ready", items: ready },
+      { key: "review" as GroupKey, label: "Review", items: review },
+      { key: "done" as GroupKey, label: "Done", items: done },
+    ];
   });
 
   let editingId = $state<string | null>(null);


### PR DESCRIPTION
## Summary
- Always render READY, REVIEW, and DONE groups in the sidebar, even when they have 0 workspaces
- Previously, empty groups were hidden which made the sidebar layout inconsistent

## Test plan
- [x] Verify all three group headers (Ready, Review, Done) appear in the sidebar when some have 0 items
- [x] Verify counts display correctly (including `0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)