### PR TITLE
feat: add default thinking & plan mode toggles in repo settings

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -44,6 +44,10 @@ pub struct RepoSettings {
     pub remove_script: String,
     #[serde(default)]
     pub pr_message: String,
+    #[serde(default)]
+    pub default_thinking: bool,
+    #[serde(default)]
+    pub default_plan: bool,
 }
 
 pub struct TerminalHandle {

--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -27,6 +27,8 @@
     run_script: "",
     remove_script: "",
     pr_message: "",
+    default_thinking: false,
+    default_plan: false,
   });
   let saveStatus = $state<"idle" | "saving" | "saved">("idle");
   let saveTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -182,6 +184,39 @@
         <span class="autosave-status" class:visible={saveStatus !== "idle"}>
           {saveStatus === "saving" ? "Saving..." : "Saved"}
         </span>
+      </div>
+
+      <div class="setting-block">
+        <div class="setting-meta">
+          <span class="setting-name">Default modes</span>
+          <span class="setting-desc">New workspaces start with these modes enabled</span>
+        </div>
+        <div class="toggle-group">
+          <label class="toggle-row">
+            <span class="toggle-label">Thinking</span>
+            <button
+              class="toggle-switch"
+              class:on={settings.default_thinking}
+              onclick={() => { settings.default_thinking = !settings.default_thinking; scheduleAutosave(); }}
+              role="switch"
+              aria-checked={settings.default_thinking}
+            >
+              <span class="toggle-knob"></span>
+            </button>
+          </label>
+          <label class="toggle-row">
+            <span class="toggle-label">Plan</span>
+            <button
+              class="toggle-switch"
+              class:on={settings.default_plan}
+              onclick={() => { settings.default_plan = !settings.default_plan; scheduleAutosave(); }}
+              role="switch"
+              aria-checked={settings.default_plan}
+            >
+              <span class="toggle-knob"></span>
+            </button>
+          </label>
+        </div>
       </div>
 
       <div class="setting-block">
@@ -513,6 +548,63 @@
     padding: 0.1rem 0.35rem;
     border-radius: 3px;
     font-size: 0.78rem;
+  }
+
+  /* ── Toggle switches ─────────────── */
+
+  .toggle-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+  }
+
+  .toggle-label {
+    font-size: 0.82rem;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .toggle-switch {
+    position: relative;
+    width: 36px;
+    height: 20px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+    padding: 0;
+  }
+
+  .toggle-switch.on {
+    background: color-mix(in srgb, var(--accent) 30%, var(--bg-card));
+    border-color: var(--accent);
+  }
+
+  .toggle-knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    background: var(--text-dim);
+    border-radius: 50%;
+    transition: transform 0.15s, background 0.15s;
+  }
+
+  .toggle-switch.on .toggle-knob {
+    transform: translateX(16px);
+    background: var(--accent);
   }
 
   .pr-message-field {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -288,6 +288,8 @@ export interface RepoSettings {
   run_script: string;
   remove_script: string;
   pr_message: string;
+  default_thinking: boolean;
+  default_plan: boolean;
 }
 
 export async function getRepoSettings(repoId: string): Promise<RepoSettings> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -351,7 +351,7 @@
   async function handleSend(prompt: string, images: PastedImage[] = [], mentions: Mention[] = [], planMode: boolean = false) {
     if (!selectedWsId) return;
     const wsId = selectedWsId;
-    const thinkingMode = thinkingModeByWorkspace.get(wsId) ?? false;
+    const thinkingMode = thinkingModeByWorkspace.get(wsId) ?? repoSettings?.default_thinking ?? false;
 
     // Save images to workspace dir, collect file paths
     let imagePaths: string[] = [];
@@ -709,8 +709,8 @@
                 <ChatPanel
                   workspaceId={ws.id}
                   creating={ws.id === creatingWsId}
-                  planMode={planModeByWorkspace.get(ws.id) ?? false}
-                  thinkingMode={thinkingModeByWorkspace.get(ws.id) ?? false}
+                  planMode={planModeByWorkspace.get(ws.id) ?? repoSettings?.default_plan ?? false}
+                  thinkingMode={thinkingModeByWorkspace.get(ws.id) ?? repoSettings?.default_thinking ?? false}
                   onSend={(prompt, images, mentions, planMode) => handleSend(prompt, images, mentions, planMode)}
                   onStop={handleStop}
                   onPlanModeChange={(enabled) => planModeByWorkspace.set(ws.id, enabled)}


### PR DESCRIPTION
## Summary
- Adds `default_thinking` and `default_plan` boolean fields to `RepoSettings` (Rust + TS)
- Adds toggle switches in Settings → Agent section for configuring defaults
- New workspaces inherit their initial Thinking/Plan state from repo settings; per-workspace overrides still take precedence

## Test plan
- [ ] Open Settings → Agent → verify "Default modes" toggles appear and auto-save
- [ ] Enable default thinking → create new workspace → verify Thinking pill is active
- [ ] Toggle off per-workspace → verify override persists
- [ ] Restart app → verify settings round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)