### PR TITLE
refactor: move workspace actions to titlebar

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -10,12 +10,14 @@
     activeRepo: RepoDetail;
     selectedWs: WorkspaceInfo | undefined;
     prStatus: PrStatus | undefined;
+    wsChanges: { additions: number; deletions: number } | undefined;
     onSelectRepo: (repo: RepoDetail) => void;
     onAddRepo: () => void;
     onSettings: () => void;
+    onPrAction: () => void;
   }
 
-  let { repos, activeRepo, selectedWs, prStatus, onSelectRepo, onAddRepo, onSettings }: Props =
+  let { repos, activeRepo, selectedWs, prStatus, wsChanges, onSelectRepo, onAddRepo, onSettings, onPrAction }: Props =
     $props();
 
   let dropdownRef: Dropdown | undefined = $state();
@@ -79,6 +81,9 @@
         <span>Add repository</span>
       </button>
     </Dropdown>
+    <button class="settings-btn" onclick={onSettings} title="Repository settings">
+      <Settings size={14} />
+    </button>
   </div>
 
   <div class="titlebar-right">
@@ -105,14 +110,29 @@
         <span class="breadcrumb-sep">›</span>
         <span class="breadcrumb-base">{activeRepo.default_branch}</span>
       </span>
+
+      {#if prStatus?.state === "open"}
+        {#if prStatus.mergeable === "conflicting"}
+          <button class="action-badge conflicts" onclick={onPrAction}>Conflicts</button>
+        {:else if prStatus.checks === "failing"}
+          <button class="action-badge checks-fail" onclick={onPrAction}>Fix issues</button>
+        {:else if prStatus.checks === "pending"}
+          <span class="status-label checks-pending"><Loader size={10} class="status-icon spinning" /> PR #{prStatus.number} · Checks</span>
+        {:else if (prStatus.ahead_by ?? 0) > 0}
+          <button class="action-badge push-needed" onclick={onPrAction}>Push</button>
+        {:else}
+          <button class="action-badge mergeable" onclick={onPrAction}>Merge #{prStatus.number}</button>
+        {/if}
+      {:else if prStatus?.state === "merged"}
+        <span class="status-label merged"><Check size={10} class="status-icon" /> Done</span>
+      {:else if wsChanges && (wsChanges.additions > 0 || wsChanges.deletions > 0)}
+        <button class="action-badge create-pr" onclick={onPrAction} disabled={selectedWs.status === "running"}>Push & create PR</button>
+      {/if}
     {:else}
       <span class="breadcrumb">
         <span class="breadcrumb-base">{activeRepo.default_branch}</span>
       </span>
     {/if}
-    <button class="settings-btn" onclick={onSettings} title="Repository settings">
-      <Settings size={14} />
-    </button>
   </div>
 </header>
 
@@ -288,5 +308,107 @@
   .settings-btn:hover {
     color: var(--text-primary);
     background: var(--border);
+  }
+
+  /* ── Action badges (clickable) ─────────────────── */
+
+  .action-badge {
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.2rem 0.55rem;
+    border-radius: 4px;
+    border: 1px solid;
+    cursor: pointer;
+    font-family: inherit;
+    background: transparent;
+    margin-left: 0.25rem;
+  }
+
+  .action-badge.create-pr {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    background: color-mix(in srgb, var(--accent) 7%, transparent);
+  }
+
+  .action-badge.create-pr:hover:not(:disabled) {
+    filter: brightness(1.2);
+  }
+
+  .action-badge.create-pr:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  .action-badge.push-needed {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    background: color-mix(in srgb, var(--accent) 7%, transparent);
+  }
+
+  .action-badge.push-needed:hover {
+    filter: brightness(1.2);
+  }
+
+  .action-badge.mergeable {
+    color: var(--status-ok);
+    border-color: color-mix(in srgb, var(--status-ok) 40%, transparent);
+    background: color-mix(in srgb, var(--status-ok) 7%, transparent);
+  }
+
+  .action-badge.mergeable:hover {
+    filter: brightness(1.2);
+  }
+
+  .action-badge.checks-fail {
+    color: var(--diff-del);
+    border-color: color-mix(in srgb, var(--diff-del) 40%, transparent);
+    background: color-mix(in srgb, var(--diff-del) 7%, transparent);
+  }
+
+  .action-badge.checks-fail:hover {
+    filter: brightness(1.2);
+  }
+
+  .action-badge.conflicts {
+    color: #c87e7e;
+    border-color: color-mix(in srgb, #c87e7e 40%, transparent);
+    background: color-mix(in srgb, #c87e7e 7%, transparent);
+  }
+
+  .action-badge.conflicts:hover {
+    filter: brightness(1.2);
+  }
+
+  /* ── Status labels (non-interactive, no bg/border) */
+
+  .status-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--text-dim);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-left: 0.25rem;
+  }
+
+  .status-label.merged {
+    color: var(--status-ok);
+  }
+
+  .status-label.checks-pending {
+    animation: badge-pulse 2s ease-in-out infinite;
+  }
+
+  .status-label :global(.status-icon) {
+    flex-shrink: 0;
+  }
+
+  .status-label :global(.status-icon.spinning) {
+    animation: spin 1.5s linear infinite;
+  }
+
+  @keyframes badge-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -625,9 +625,11 @@
       {activeRepo}
       {selectedWs}
       prStatus={selectedWsId ? prStatusMap.get(selectedWsId) : undefined}
+      wsChanges={selectedWsId ? changeCounts.get(selectedWsId) : undefined}
       onSelectRepo={selectRepo}
       onAddRepo={handleOpenRepo}
       onSettings={() => (showSettings = true)}
+      onPrAction={handlePrAction}
     />
 
     {#if error}
@@ -671,28 +673,6 @@
                   {/if}
                 </button>
               {/each}
-            </div>
-            <div class="tab-bar-right">
-              {#if prStatusMap.get(selectedWs.id)?.state === "open"}
-                {#if prStatusMap.get(selectedWs.id)?.mergeable === "conflicting"}
-                  <button class="status-badge conflicts" onclick={handlePrAction}>Conflicts</button>
-                {:else if prStatusMap.get(selectedWs.id)?.checks === "failing"}
-                  <button class="status-badge checks-fail" onclick={handlePrAction}>Fix issues</button>
-                {:else if prStatusMap.get(selectedWs.id)?.checks === "pending"}
-                  <span class="status-badge checks-pending">PR #{prStatusMap.get(selectedWs.id)?.number} · Checks</span>
-                {:else if (prStatusMap.get(selectedWs.id)?.ahead_by ?? 0) > 0}
-                  <button class="status-badge push-needed" onclick={handlePrAction}>Push</button>
-                {:else}
-                  <button class="status-badge mergeable" onclick={handlePrAction}>Merge #{prStatusMap.get(selectedWs.id)?.number}</button>
-                {/if}
-              {:else if prStatusMap.get(selectedWs.id)?.state === "merged"}
-                <span class="status-badge merged">Done</span>
-              {:else}
-                {@const cc = changeCounts.get(selectedWs.id)}
-                {#if cc && (cc.additions > 0 || cc.deletions > 0)}
-                  <button class="status-badge create-pr" onclick={handlePrAction} disabled={selectedWs.status === "running"}>Push & Create PR</button>
-                {/if}
-              {/if}
             </div>
           </div>
 
@@ -980,110 +960,6 @@
     color: var(--text-bright);
     background: var(--border);
   }
-
-  .tab-bar-right {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .status-badge {
-    font-size: 0.68rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 0.2rem 0.55rem;
-    border-radius: 4px;
-    border: 1px solid;
-  }
-
-  .status-badge.merged {
-    color: var(--text-dim);
-    border-color: var(--border-light);
-  }
-
-  .status-badge.pr-open {
-    color: #7e8ec8;
-    border-color: color-mix(in srgb, #7e8ec8 40%, transparent);
-    text-transform: none;
-  }
-
-  .status-badge.checks-pending {
-    color: var(--text-dim);
-    border-color: var(--border-light);
-    text-transform: none;
-    animation: badge-pulse 2s ease-in-out infinite;
-  }
-
-  .status-badge.checks-fail {
-    color: var(--diff-del);
-    border-color: color-mix(in srgb, var(--diff-del) 40%, transparent);
-    background: color-mix(in srgb, var(--diff-del) 7%, transparent);
-    text-transform: none;
-  }
-
-  .status-badge.push-needed {
-    color: var(--accent);
-    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-    background: color-mix(in srgb, var(--accent) 7%, transparent);
-    cursor: pointer;
-    text-transform: none;
-  }
-
-  .status-badge.push-needed:hover {
-    filter: brightness(1.2);
-  }
-
-  .status-badge.mergeable {
-    color: var(--status-ok);
-    border-color: color-mix(in srgb, var(--status-ok) 40%, transparent);
-    background: color-mix(in srgb, var(--status-ok) 7%, transparent);
-    cursor: pointer;
-    text-transform: none;
-  }
-
-  .status-badge.mergeable:hover {
-    filter: brightness(1.2);
-  }
-
-  .status-badge.create-pr {
-    color: var(--accent);
-    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-    background: color-mix(in srgb, var(--accent) 7%, transparent);
-    cursor: pointer;
-    text-transform: none;
-  }
-
-  .status-badge.create-pr:hover:not(:disabled) {
-    filter: brightness(1.2);
-  }
-
-  .status-badge.create-pr:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-  }
-
-  .status-badge.checks-fail {
-    cursor: pointer;
-  }
-
-  .status-badge.conflicts {
-    color: #c87e7e;
-    border-color: color-mix(in srgb, #c87e7e 40%, transparent);
-    background: color-mix(in srgb, #c87e7e 7%, transparent);
-    cursor: pointer;
-    text-transform: none;
-  }
-
-  .status-badge.conflicts:hover {
-    filter: brightness(1.2);
-  }
-
-  @keyframes badge-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.6; }
-  }
-
 
   /* ── Tab content ──────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Move PR action badges and status labels from the tab bar to the titlebar (top-right)
- Move settings cog icon from top-right to sit next to the repo dropdown (left side)
- Non-interactive labels ("Done", "Checks pending") now render as plain text with icon prefixes — no border/background
- Normalize text capitalization to sentence case across all action labels

## Test plan
- [ ] Verify action badges (Push & create PR, Merge, Push, Conflicts, Fix issues) appear in titlebar
- [ ] Verify "Done" label shows green check icon and green text, visually distinct from breadcrumb
- [ ] Verify settings cog appears next to repo dropdown on the left
- [ ] Verify tab bar no longer has action badges on the right side

🤖 Generated with [Claude Code](https://claude.com/claude-code)