### PR TITLE
refactor: titlebar polish — button groups, icons, centered breadcrumb

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -52,7 +52,7 @@
     display: flex;
     align-items: center;
     gap: 0.4rem;
-    padding: 0.25rem 0.5rem;
+    padding: 0.4rem 0.5rem;
     background: transparent;
     border: 1px solid var(--border-light);
     border-radius: 5px;

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import type { RepoDetail, WorkspaceInfo, PrStatus } from "$lib/ipc";
-  import { Settings, ExternalLink, Check, X, Loader, Plus } from "lucide-svelte";
+  import { Settings, ExternalLink, Check, X, Loader, Plus, GitPullRequestCreate, GitMerge, ArrowUp, AlertTriangle, Wrench } from "lucide-svelte";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import Dropdown from "./Dropdown.svelte";
 
@@ -56,82 +56,78 @@
   ondblclick={handleDoubleClick}
 >
   <div class="titlebar-left">
-    <Dropdown bind:this={dropdownRef}>
-      {#snippet trigger()}
-        <span class="repo-dot" class:has-running={false}></span>
-        <span class="repo-name">{activeRepo.display_name}</span>
-      {/snippet}
-
-      {#each repos as repo}
-        <button
-          class="dropdown-item"
-          class:active={repo.id === activeRepo.id}
-          onclick={() => selectRepo(repo)}
-        >
+    <div class="btn-group">
+      <Dropdown bind:this={dropdownRef}>
+        {#snippet trigger()}
           <span class="repo-dot" class:has-running={false}></span>
-          <span class="dropdown-item-name">{repo.display_name}</span>
-          {#if repo.id === activeRepo.id}
-            <Check size={12} class="check-mark" />
-          {/if}
-        </button>
-      {/each}
-      <div class="dropdown-divider"></div>
-      <button class="dropdown-item add-item" onclick={handleAddRepo}>
-        <Plus size={12} />
-        <span>Add repository</span>
-      </button>
-    </Dropdown>
-    <button class="settings-btn" onclick={onSettings} title="Repository settings">
-      <Settings size={14} />
-    </button>
-  </div>
+          <span class="repo-name">{activeRepo.display_name}</span>
+        {/snippet}
 
-  <div class="titlebar-right">
-    {#if selectedWs}
-      <span class="breadcrumb">
-        {#if prStatus && prStatus.state === "open"}
+        {#each repos as repo}
           <button
-            class="breadcrumb-pr"
-            onclick={() => openUrl(prStatus!.url)}
-            title="Open PR in browser"
+            class="dropdown-item"
+            class:active={repo.id === activeRepo.id}
+            onclick={() => selectRepo(repo)}
           >
-            #{prStatus.number}
-            {#if prStatus.checks === "passing"}
-              <Check size={11} class="check-icon pass" />
-            {:else if prStatus.checks === "failing"}
-              <X size={11} class="check-icon fail" />
-            {:else if prStatus.checks === "pending"}
-              <Loader size={11} class="check-icon pending" />
+            <span class="repo-dot" class:has-running={false}></span>
+            <span class="dropdown-item-name">{repo.display_name}</span>
+            {#if repo.id === activeRepo.id}
+              <Check size={12} class="check-mark" />
             {/if}
           </button>
-          <span class="breadcrumb-sep">·</span>
-        {/if}
+        {/each}
+        <div class="dropdown-divider"></div>
+        <button class="dropdown-item add-item" onclick={handleAddRepo}>
+          <Plus size={12} />
+          <span>Add repository</span>
+        </button>
+      </Dropdown>
+      <button class="settings-btn" onclick={onSettings} title="Repository settings">
+        <Settings size={14} />
+      </button>
+    </div>
+  </div>
+
+  <div class="titlebar-center">
+    {#if selectedWs}
+      <span class="breadcrumb">
         <span class="breadcrumb-branch">{selectedWs.branch}</span>
         <span class="breadcrumb-sep">›</span>
         <span class="breadcrumb-base">{activeRepo.default_branch}</span>
       </span>
-
-      {#if prStatus?.state === "open"}
-        {#if prStatus.mergeable === "conflicting"}
-          <button class="action-badge conflicts" onclick={onPrAction}>Conflicts</button>
-        {:else if prStatus.checks === "failing"}
-          <button class="action-badge checks-fail" onclick={onPrAction}>Fix issues</button>
-        {:else if prStatus.checks === "pending"}
-          <span class="status-label checks-pending"><Loader size={10} class="status-icon spinning" /> PR #{prStatus.number} · Checks</span>
-        {:else if (prStatus.ahead_by ?? 0) > 0}
-          <button class="action-badge push-needed" onclick={onPrAction}>Push</button>
-        {:else}
-          <button class="action-badge mergeable" onclick={onPrAction}>Merge #{prStatus.number}</button>
-        {/if}
-      {:else if prStatus?.state === "merged"}
-        <span class="status-label merged"><Check size={10} class="status-icon" /> Done</span>
-      {:else if wsChanges && (wsChanges.additions > 0 || wsChanges.deletions > 0)}
-        <button class="action-badge create-pr" onclick={onPrAction} disabled={selectedWs.status === "running"}>Push & create PR</button>
-      {/if}
     {:else}
       <span class="breadcrumb">
         <span class="breadcrumb-base">{activeRepo.default_branch}</span>
       </span>
+    {/if}
+  </div>
+
+  <div class="titlebar-right">
+    {#if selectedWs}
+      {#if prStatus?.state === "open"}
+        <div class="btn-group">
+          <button class="pr-link-btn" onclick={() => openUrl(prStatus!.url)} title="Open PR #{prStatus.number} in browser">
+            <ExternalLink size={12} />
+          </button>
+          {#if prStatus.mergeable === "conflicting"}
+            <button class="action-badge conflicts" onclick={onPrAction}><AlertTriangle size={11} /> Conflicts</button>
+          {:else if prStatus.checks === "failing"}
+            <button class="action-badge checks-fail" onclick={onPrAction}><Wrench size={11} /> Fix issues</button>
+          {:else if prStatus.checks === "pending"}
+            <span class="status-label checks-pending"><Loader size={10} class="status-icon spinning" /> Checks pending</span>
+          {:else if (prStatus.ahead_by ?? 0) > 0}
+            <button class="action-badge push-needed" onclick={onPrAction}><ArrowUp size={11} /> Push</button>
+          {:else if wsChanges && (wsChanges.additions !== prStatus.additions || wsChanges.deletions !== prStatus.deletions)}
+            <button class="action-badge push-needed" onclick={onPrAction}><ArrowUp size={11} /> Commit & push</button>
+          {:else}
+            <button class="action-badge mergeable" onclick={onPrAction}><GitMerge size={11} /> Merge</button>
+          {/if}
+        </div>
+      {:else if prStatus?.state === "merged"}
+        <span class="status-label merged"><Check size={10} class="status-icon" /> Done</span>
+      {:else if wsChanges && (wsChanges.additions > 0 || wsChanges.deletions > 0)}
+        <button class="action-badge create-pr" onclick={onPrAction} disabled={selectedWs.status === "running"}><GitPullRequestCreate size={11} /> Push & create PR</button>
+      {/if}
     {/if}
   </div>
 </header>
@@ -149,6 +145,7 @@
     user-select: none;
     cursor: default;
     flex-shrink: 0;
+    position: relative;
   }
 
   .titlebar.dev {
@@ -162,6 +159,17 @@
     gap: 0.5rem;
     /* leave room for traffic lights on macOS */
     padding-left: 78px;
+  }
+
+  .titlebar-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    pointer-events: none;
+  }
+
+  .titlebar-center .breadcrumb {
+    pointer-events: auto;
   }
 
   .titlebar-right {
@@ -260,34 +268,36 @@
     color: var(--text-dim);
   }
 
-  .breadcrumb-pr {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.2rem;
-    background: none;
+  /* ── Button groups (segmented) ───────────────── */
+
+  .btn-group {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid var(--border-light);
+    border-radius: 5px;
+  }
+
+  .btn-group :global(.dropdown-trigger) {
     border: none;
-    color: var(--accent);
+    border-radius: 4px 0 0 4px;
+    border-right: 1px solid var(--border-light);
+  }
+
+  .pr-link-btn {
+    background: var(--bg-card);
+    color: var(--text-secondary);
     cursor: pointer;
-    font-family: inherit;
-    font-size: 0.75rem;
-    padding: 0;
+    padding: 0.4rem 0.45rem;
+    border: none;
+    border-right: 1px solid var(--border-light);
+    border-radius: 4px 0 0 4px;
+    display: flex;
+    align-items: center;
   }
 
-  .breadcrumb-pr:hover {
-    text-decoration: underline;
-  }
-
-  .breadcrumb-pr :global(.check-icon.pass) {
-    color: var(--status-ok);
-  }
-
-  .breadcrumb-pr :global(.check-icon.fail) {
-    color: var(--diff-del);
-  }
-
-  .breadcrumb-pr :global(.check-icon.pending) {
-    color: var(--text-dim);
-    animation: spin 1.5s linear infinite;
+  .pr-link-btn:hover {
+    color: var(--text-primary);
+    background: var(--border);
   }
 
   @keyframes spin {
@@ -296,13 +306,15 @@
   }
 
   .settings-btn {
-    background: none;
-    border: none;
+    background: var(--bg-card);
     color: var(--text-dim);
     cursor: pointer;
     font-size: 0.9rem;
-    padding: 0.2rem 0.35rem;
-    border-radius: 4px;
+    padding: 0.4rem 0.45rem;
+    border: none;
+    border-radius: 0 4px 4px 0;
+    display: flex;
+    align-items: center;
   }
 
   .settings-btn:hover {
@@ -315,13 +327,21 @@
   .action-badge {
     font-size: 0.68rem;
     font-weight: 600;
-    padding: 0.2rem 0.55rem;
-    border-radius: 4px;
+    padding: 0.35rem 0.55rem;
+    border-radius: 5px;
     border: 1px solid;
     cursor: pointer;
     font-family: inherit;
     background: transparent;
-    margin-left: 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .btn-group .action-badge,
+  .btn-group .status-label {
+    border: none;
+    border-radius: 0 4px 4px 0;
   }
 
   .action-badge.create-pr {
@@ -388,7 +408,10 @@
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    margin-left: 0.25rem;
+  }
+
+  .btn-group .status-label {
+    padding: 0.35rem 0.55rem;
   }
 
   .status-label.merged {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -490,7 +490,13 @@
       } else if (pr.ahead_by > 0) {
         sendPrompt(wsId, `Push local commits to origin. Run \`git push\`. Only say "Pushed successfully" on success. If it fails, explain why.`, `Pushing to PR #${pr.number}`);
       } else {
-        sendPrompt(wsId, `Merge PR #${pr.number} using \`gh pr merge ${pr.number} --squash --delete-branch=false\`. Only say "PR #${pr.number} merged successfully" on success. If it fails, explain why.`, `Merging PR #${pr.number}`);
+        const cc = changeCounts.get(wsId);
+        const hasLocalChanges = cc && (cc.additions !== pr.additions || cc.deletions !== pr.deletions);
+        if (hasLocalChanges) {
+          sendPrompt(wsId, `There are uncommitted local changes. Commit them with a descriptive message and push to origin. Only say "Pushed successfully" on success. If it fails, explain why.`, `Committing & pushing to PR #${pr.number}`);
+        } else {
+          sendPrompt(wsId, `Merge PR #${pr.number} using \`gh pr merge ${pr.number} --squash --delete-branch=false\`. Only say "PR #${pr.number} merged successfully" on success. If it fails, explain why.`, `Merging PR #${pr.number}`);
+        }
       }
       activeTab = "chat";
       return;


### PR DESCRIPTION
## Summary
- Group dropdown+settings and PR link+action badge into segmented button groups with shared borders
- Add lucide icons to all action badges (GitMerge, ArrowUp, Wrench, AlertTriangle, etc.)
- Replace `#N` text link with an ExternalLink icon button grouped with the action badge
- Center breadcrumb in titlebar via absolute positioning
- Detect uncommitted local changes (local diff ≠ PR diff) and show "Commit & push" instead of "Merge"
- Increase vertical padding on all titlebar controls to better fill the 40px titlebar height

## Test plan
- [ ] Dropdown+settings button group renders with shared border and internal divider
- [ ] Dropdown menu opens correctly (not clipped by group container)
- [ ] PR link + action badge group renders correctly with all states (merge, push, conflicts, etc.)
- [ ] Breadcrumb is visually centered in the titlebar
- [ ] "Commit & push" appears when local changes differ from PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)