### PR TITLE
feat: ripgrep-powered live search modal (⌘⇧F)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1302,6 +1302,144 @@ pub fn search_workspace_files(
     Ok(results)
 }
 
+// ── Grep (content search) ────────────────────────────────────────────
+
+#[derive(Clone, serde::Serialize)]
+pub struct GrepMatch {
+    pub path: String,
+    pub line_number: u32,
+    pub column: u32,
+    pub line_content: String,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct GrepResult {
+    pub matches: Vec<GrepMatch>,
+    pub truncated: bool,
+}
+
+#[tauri::command]
+pub async fn grep_workspace(
+    workspace_id: String,
+    pattern: String,
+    is_regex: bool,
+    case_sensitive: bool,
+    state: State<'_, Arc<Mutex<AppState>>>,
+) -> Result<GrepResult, String> {
+    let worktree_path = {
+        let st = state.lock().map_err(|e| e.to_string())?;
+        let ws = st
+            .workspaces
+            .get(&workspace_id)
+            .ok_or("Workspace not found")?;
+        ws.worktree_path.clone()
+    };
+
+    let pattern_trimmed = pattern.trim().to_string();
+    if pattern_trimmed.is_empty() {
+        return Ok(GrepResult {
+            matches: vec![],
+            truncated: false,
+        });
+    }
+
+    let wt = worktree_path.clone();
+    let output = tauri::async_runtime::spawn_blocking(move || {
+        let mut cmd = std::process::Command::new("rg");
+        cmd.arg("--json")
+            .arg(if case_sensitive { "--case-sensitive" } else { "--smart-case" })
+            .arg("--max-count=5")
+            .arg("--max-columns=500")
+            .arg("--max-filesize=1M");
+
+        if !is_regex {
+            cmd.arg("--fixed-strings");
+        }
+
+        cmd.arg("--").arg(&pattern_trimmed).current_dir(&wt);
+        cmd.output()
+    })
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            "ripgrep (rg) not found — install via 'brew install ripgrep'".to_string()
+        } else {
+            format!("Failed to run rg: {}", e)
+        }
+    })?;
+
+    // Exit code 1 = no matches (not an error), 2 = regex error or similar
+    if !output.status.success() && output.status.code() != Some(1) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("rg error: {}", stderr.trim()));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut matches = Vec::new();
+    let mut truncated = false;
+    let max_results = 100;
+
+    let worktree_prefix = worktree_path.to_string_lossy();
+
+    for line in stdout.lines() {
+        if matches.len() >= max_results {
+            truncated = true;
+            break;
+        }
+
+        let parsed: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        if parsed.get("type").and_then(|t| t.as_str()) != Some("match") {
+            continue;
+        }
+
+        let data = match parsed.get("data") {
+            Some(d) => d,
+            None => continue,
+        };
+
+        let raw_path = data
+            .pointer("/path/text")
+            .and_then(|p| p.as_str())
+            .unwrap_or("");
+        // Make path relative to worktree
+        let rel_path = raw_path
+            .strip_prefix(worktree_prefix.as_ref())
+            .unwrap_or(raw_path)
+            .trim_start_matches('/');
+
+        let line_number = data
+            .get("line_number")
+            .and_then(|n| n.as_u64())
+            .unwrap_or(0) as u32;
+
+        let line_content = data
+            .pointer("/lines/text")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .trim_end()
+            .to_string();
+
+        let column = data
+            .pointer("/submatches/0/start")
+            .and_then(|s| s.as_u64())
+            .unwrap_or(0) as u32;
+
+        matches.push(GrepMatch {
+            path: rel_path.to_string(),
+            line_number,
+            column,
+            line_content,
+        });
+    }
+
+    Ok(GrepResult { matches, truncated })
+}
+
 #[tauri::command]
 pub fn read_workspace_file(
     workspace_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,6 +80,7 @@ pub fn run() {
             commands::get_changed_files,
             commands::get_diff,
             commands::search_workspace_files,
+            commands::grep_workspace,
             commands::read_workspace_file,
             commands::run_script,
             commands::save_messages,

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -28,6 +28,10 @@
     extension: string;  // png, jpg, etc.
   }
 
+  export interface ChatPanelApi {
+    addMention: (mention: Mention) => void;
+  }
+
   interface Props {
     workspaceId: string;
     creating?: boolean;
@@ -39,9 +43,10 @@
     onThinkingModeChange?: (enabled: boolean) => void;
     onExecutePlan?: () => void;
     onMentionClick?: (path: string) => void;
+    onReady?: (api: ChatPanelApi) => void;
   }
 
-  let { workspaceId, creating = false, planMode = false, thinkingMode = false, onSend, onStop, onPlanModeChange, onThinkingModeChange, onExecutePlan, onMentionClick }: Props = $props();
+  let { workspaceId, creating = false, planMode = false, thinkingMode = false, onSend, onStop, onPlanModeChange, onThinkingModeChange, onExecutePlan, onMentionClick, onReady }: Props = $props();
 
   /** Split text into segments, replacing @displayName with mention references. */
   type TextSegment = { kind: "text"; value: string } | { kind: "mention"; mention: MessageMention };
@@ -86,6 +91,18 @@
 
   // Mention input + autocomplete state
   let mentionInputApi: MentionInputApi | undefined = $state();
+
+  // Expose ChatPanelApi via callback
+  $effect(() => {
+    if (mentionInputApi && onReady) {
+      onReady({
+        addMention: (mention: Mention) => {
+          mentionInputApi?.appendMention(mention);
+          mentionInputApi?.focus();
+        },
+      });
+    }
+  });
   let autocompleteApi: MentionAutocompleteApi | undefined = $state();
   let autocompleteVisible = $state(false);
   let autocompleteResults = $state<FileSearchResult[]>([]);

--- a/src/lib/components/MentionInput.svelte
+++ b/src/lib/components/MentionInput.svelte
@@ -3,6 +3,7 @@
     type: "file" | "folder";
     path: string;
     displayName: string;
+    lineNumber?: number;
   }
 
   export interface MentionInputValue {
@@ -12,6 +13,7 @@
 
   export interface MentionInputApi {
     insertMention: (mention: Mention) => void;
+    appendMention: (mention: Mention) => void;
     focus: () => void;
     submit: () => void;
   }
@@ -43,19 +45,7 @@
     editorEl?.focus();
   }
 
-  function insertMention(mention: Mention) {
-    if (!editorEl || !atTriggerRange) return;
-
-    const sel = window.getSelection();
-    if (!sel || sel.rangeCount === 0) return;
-
-    // Build the range from @ to current cursor
-    const currentRange = sel.getRangeAt(0);
-    const replaceRange = document.createRange();
-    replaceRange.setStart(atTriggerRange.startContainer, atTriggerRange.startOffset);
-    replaceRange.setEnd(currentRange.startContainer, currentRange.startOffset);
-
-    // Create chip element
+  function createMentionChip(mention: Mention): HTMLSpanElement {
     const chip = document.createElement("span");
     chip.className = "mention-chip";
     chip.contentEditable = "false";
@@ -68,6 +58,32 @@
     chip.appendChild(icon);
 
     chip.appendChild(document.createTextNode(mention.displayName));
+    return chip;
+  }
+
+  function placeCursorAfter(node: Node) {
+    const sel = window.getSelection();
+    if (!sel) return;
+    const newRange = document.createRange();
+    newRange.setStartAfter(node);
+    newRange.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(newRange);
+  }
+
+  function insertMention(mention: Mention) {
+    if (!editorEl || !atTriggerRange) return;
+
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return;
+
+    // Build the range from @ to current cursor
+    const currentRange = sel.getRangeAt(0);
+    const replaceRange = document.createRange();
+    replaceRange.setStart(atTriggerRange.startContainer, atTriggerRange.startOffset);
+    replaceRange.setEnd(currentRange.startContainer, currentRange.startOffset);
+
+    const chip = createMentionChip(mention);
 
     // Replace the @query text with the chip
     replaceRange.deleteContents();
@@ -76,22 +92,26 @@
     // Insert a space after the chip so cursor can continue typing
     const spacer = document.createTextNode("\u00A0");
     chip.after(spacer);
-
-    // Place cursor after the spacer
-    const newRange = document.createRange();
-    newRange.setStartAfter(spacer);
-    newRange.collapse(true);
-    sel.removeAllRanges();
-    sel.addRange(newRange);
+    placeCursorAfter(spacer);
 
     // Clear trigger state
     atTriggerRange = null;
     onQueryChange(null);
   }
 
+  function appendMention(mention: Mention) {
+    if (!editorEl) return;
+
+    const chip = createMentionChip(mention);
+    const spacer = document.createTextNode("\u00A0");
+    editorEl.appendChild(chip);
+    chip.after(spacer);
+    placeCursorAfter(spacer);
+  }
+
   // Expose API via bindable ref
   $effect(() => {
-    ref = { insertMention, focus, submit: handleSubmit };
+    ref = { insertMention, appendMention, focus, submit: handleSubmit };
   });
 
   function serialize(): MentionInputValue {

--- a/src/lib/components/SearchModal.svelte
+++ b/src/lib/components/SearchModal.svelte
@@ -1,0 +1,477 @@
+<script lang="ts">
+  import { grepWorkspace, readFile, type GrepMatch } from "$lib/ipc";
+  import { Search } from "lucide-svelte";
+
+  interface Props {
+    workspaceId: string;
+    onClose: () => void;
+    onAddToContext: (path: string, displayName: string, lineNumber: number) => void;
+    onOpenInFiles: (path: string) => void;
+  }
+
+  let { workspaceId, onClose, onAddToContext, onOpenInFiles }: Props = $props();
+
+  let query = $state("");
+  let isRegex = $state(false);
+  let caseSensitive = $state(false);
+  let results = $state<GrepMatch[]>([]);
+  let truncated = $state(false);
+  let selectedIndex = $state(0);
+  let loading = $state(false);
+  let errorMsg = $state("");
+  let inputEl: HTMLInputElement | undefined = $state();
+
+  // Preview state
+  let previewContent = $state<string | null>(null);
+  let previewPath = $state<string | null>(null);
+  let previewLine = $state(0);
+  let previewEl: HTMLPreElement | undefined = $state();
+
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  $effect(() => {
+    inputEl?.focus();
+  });
+
+  // Debounced search
+  $effect(() => {
+    const q = query;
+    const regex = isRegex;
+    const matchCase = caseSensitive;
+    clearTimeout(debounceTimer);
+    if (!q.trim()) {
+      results = [];
+      truncated = false;
+      selectedIndex = 0;
+      previewContent = null;
+      previewPath = null;
+      errorMsg = "";
+      return;
+    }
+    loading = true;
+    debounceTimer = setTimeout(async () => {
+      try {
+        const res = await grepWorkspace(workspaceId, q, regex, matchCase);
+        results = res.matches;
+        truncated = res.truncated;
+        selectedIndex = 0;
+        errorMsg = "";
+      } catch (e) {
+        errorMsg = String(e);
+        results = [];
+        truncated = false;
+      } finally {
+        loading = false;
+      }
+    }, 150);
+  });
+
+  // Fetch preview when selection changes
+  $effect(() => {
+    const match = results[selectedIndex];
+    if (!match) {
+      previewContent = null;
+      previewPath = null;
+      return;
+    }
+    previewLine = match.line_number;
+    if (match.path === previewPath) {
+      // Same file, just scroll
+      scrollPreviewToLine();
+      return;
+    }
+    previewPath = match.path;
+    readFile(workspaceId, match.path)
+      .then((content) => {
+        previewContent = content;
+        // Scroll after content renders
+        requestAnimationFrame(() => scrollPreviewToLine());
+      })
+      .catch(() => {
+        previewContent = null;
+      });
+  });
+
+  function scrollPreviewToLine() {
+    if (!previewEl) return;
+    const lineEl = previewEl.querySelector(`[data-line="${previewLine}"]`);
+    if (lineEl) {
+      lineEl.scrollIntoView({ block: "center" });
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        if (results.length > 0) {
+          selectedIndex = Math.min(selectedIndex + 1, results.length - 1);
+          scrollSelectedIntoView();
+        }
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        if (results.length > 0) {
+          selectedIndex = Math.max(selectedIndex - 1, 0);
+          scrollSelectedIntoView();
+        }
+        break;
+      case "Enter": {
+        e.preventDefault();
+        const match = results[selectedIndex];
+        if (!match) break;
+        if (e.metaKey) {
+          onOpenInFiles(match.path);
+        } else {
+          const name = match.path.split("/").pop() ?? match.path;
+          onAddToContext(match.path, name, match.line_number);
+        }
+        break;
+      }
+    }
+  }
+
+  function scrollSelectedIntoView() {
+    requestAnimationFrame(() => {
+      const el = document.querySelector(".grep-result-item.selected");
+      el?.scrollIntoView({ block: "nearest" });
+    });
+  }
+
+  function handleBackdropClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  }
+
+  function formatPath(path: string): { dir: string; file: string } {
+    const lastSlash = path.lastIndexOf("/");
+    if (lastSlash < 0) return { dir: "", file: path };
+    return {
+      dir: path.slice(0, lastSlash + 1),
+      file: path.slice(lastSlash + 1),
+    };
+  }
+
+  let previewLines = $derived(previewContent?.split("\n") ?? []);
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="backdrop" onmousedown={handleBackdropClick}>
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div class="modal" onkeydown={handleKeydown}>
+    <div class="search-bar">
+      <Search size={14} strokeWidth={2} />
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        type="text"
+        class="search-input"
+        placeholder="Search file contents…"
+        spellcheck="false"
+        autocomplete="off"
+      />
+      <button
+        class="regex-toggle"
+        class:active={isRegex}
+        onclick={() => { isRegex = !isRegex; }}
+        title={isRegex ? "Regex mode (click for literal)" : "Literal mode (click for regex)"}
+      >.*</button>
+      <button
+        class="regex-toggle"
+        class:active={caseSensitive}
+        onclick={() => { caseSensitive = !caseSensitive; }}
+        title={caseSensitive ? "Case sensitive (click for smart case)" : "Smart case (click for case sensitive)"}
+      >Aa</button>
+    </div>
+
+    <div class="body">
+      <div class="results-pane">
+        {#if errorMsg}
+          <div class="results-error">{errorMsg}</div>
+        {:else if results.length === 0 && query.trim() && !loading}
+          <div class="results-empty">No matches</div>
+        {:else}
+          {#each results as match, i}
+            {@const { dir, file } = formatPath(match.path)}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <div
+              class="grep-result-item"
+              class:selected={i === selectedIndex}
+              role="option"
+              aria-selected={i === selectedIndex}
+              onmousedown={() => { selectedIndex = i; }}
+              ondblclick={() => {
+                const name = match.path.split("/").pop() ?? match.path;
+                onAddToContext(match.path, name, match.line_number);
+              }}
+            >
+              <div class="result-path">
+                <span class="result-dir">{dir}</span><span class="result-file">{file}</span><span class="result-line">:{match.line_number}</span>
+              </div>
+              <div class="result-content">{match.line_content}</div>
+            </div>
+          {/each}
+          {#if truncated}
+            <div class="results-truncated">Results truncated (100+ matches)</div>
+          {/if}
+        {/if}
+      </div>
+
+      <div class="preview-pane">
+        {#if previewContent !== null && previewPath}
+          <div class="preview-header">{previewPath}</div>
+          <pre class="preview-code" bind:this={previewEl}>{#each previewLines as line, i}<div
+                class="preview-line"
+                class:highlighted={i + 1 === previewLine}
+                data-line={i + 1}
+              ><span class="line-num">{i + 1}</span><span class="line-text">{line}</span></div>{/each}</pre>
+        {:else if query.trim() && results.length > 0}
+          <div class="preview-empty">Loading preview…</div>
+        {/if}
+      </div>
+    </div>
+
+    <div class="footer">
+      <span class="hint"><kbd>↑↓</kbd> navigate</span>
+      <span class="hint"><kbd>⏎</kbd> add to context</span>
+      <span class="hint"><kbd>⌘⏎</kbd> open in files</span>
+      <span class="hint"><kbd>esc</kbd> close</span>
+    </div>
+  </div>
+</div>
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 10vh;
+  }
+
+  .modal {
+    width: 900px;
+    max-width: calc(100vw - 4rem);
+    max-height: 70vh;
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
+  }
+
+  /* ── Search bar ─────────────────────── */
+
+  .search-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-dim);
+  }
+
+  .search-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: var(--text-bright);
+    font-family: inherit;
+    font-size: 0.9rem;
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--text-dim);
+  }
+
+  .regex-toggle {
+    padding: 0.15rem 0.4rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    border-radius: 4px;
+    border: 1px solid var(--border-light);
+    background: transparent;
+    color: var(--text-dim);
+    cursor: pointer;
+    line-height: 1;
+  }
+
+  .regex-toggle.active {
+    background: color-mix(in srgb, var(--accent) 20%, transparent);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  /* ── Body (results + preview) ───────── */
+
+  .body {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+  }
+
+  /* ── Results pane ───────────────────── */
+
+  .results-pane {
+    width: 40%;
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+  }
+
+  .grep-result-item {
+    padding: 0.4rem 0.75rem;
+    cursor: pointer;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .grep-result-item:hover {
+    background: var(--bg-hover);
+  }
+
+  .grep-result-item.selected {
+    background: var(--bg-active);
+  }
+
+  .result-path {
+    font-size: 0.75rem;
+    line-height: 1.3;
+    font-family: var(--font-mono);
+  }
+
+  .result-dir {
+    color: var(--text-dim);
+  }
+
+  .result-file {
+    color: var(--text-bright);
+  }
+
+  .result-line {
+    color: var(--accent);
+  }
+
+  .result-content {
+    font-size: 0.75rem;
+    font-family: var(--font-mono);
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 0.1rem;
+  }
+
+  .results-empty,
+  .results-error,
+  .results-truncated {
+    padding: 1rem;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    text-align: center;
+  }
+
+  .results-error {
+    color: #c87e7e;
+  }
+
+  /* ── Preview pane ───────────────────── */
+
+  .preview-pane {
+    width: 60%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .preview-header {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.7rem;
+    font-family: var(--font-mono);
+    color: var(--text-dim);
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .preview-code {
+    flex: 1;
+    overflow: auto;
+    margin: 0;
+    padding: 0;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    line-height: 1.5;
+  }
+
+  .preview-line {
+    display: flex;
+    padding: 0 0.75rem 0 0;
+    min-height: 1.5em;
+  }
+
+  .preview-line.highlighted {
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+  }
+
+  .line-num {
+    display: inline-block;
+    width: 3.5rem;
+    text-align: right;
+    padding-right: 0.75rem;
+    color: var(--text-dim);
+    user-select: none;
+    flex-shrink: 0;
+  }
+
+  .line-text {
+    white-space: pre;
+    color: var(--text-primary);
+  }
+
+  .preview-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-dim);
+    font-size: 0.8rem;
+  }
+
+  /* ── Footer ─────────────────────────── */
+
+  .footer {
+    display: flex;
+    gap: 1.25rem;
+    padding: 0.5rem 1rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .hint {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  kbd {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+  }
+</style>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -125,6 +125,34 @@ export async function searchWorkspaceFiles(
   });
 }
 
+// ── Content Search (Grep) ───────────────────────────────────────
+
+export interface GrepMatch {
+  path: string;
+  line_number: number;
+  column: number;
+  line_content: string;
+}
+
+export interface GrepResult {
+  matches: GrepMatch[];
+  truncated: boolean;
+}
+
+export async function grepWorkspace(
+  workspaceId: string,
+  pattern: string,
+  isRegex: boolean = false,
+  caseSensitive: boolean = false,
+): Promise<GrepResult> {
+  return invoke<GrepResult>("grep_workspace", {
+    workspaceId,
+    pattern,
+    isRegex,
+    caseSensitive,
+  });
+}
+
 export async function readWorkspaceFile(
   workspaceId: string,
   filePath: string,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -43,6 +43,8 @@
   import FileBrowser from "$lib/components/FileBrowser.svelte";
   import TerminalView from "$lib/components/Terminal.svelte";
   import RepoSettingsPanel from "$lib/components/RepoSettings.svelte";
+  import SearchModal from "$lib/components/SearchModal.svelte";
+  import type { ChatPanelApi } from "$lib/components/ChatPanel.svelte";
 
   type PanelTab = "chat" | "diff" | "files" | "terminal";
 
@@ -63,6 +65,8 @@
   let planModeByWorkspace = new SvelteMap<string, boolean>();
   let thinkingModeByWorkspace = new SvelteMap<string, boolean>();
   let fileNavigatePath = $state<string | null>(null);
+  let showSearchModal = $state(false);
+  let chatPanelApis = new SvelteMap<string, ChatPanelApi>();
 
   let selectedWs = $derived(workspaces.find((w) => w.id === selectedWsId));
   let activeWorkspaces = $derived(
@@ -119,6 +123,12 @@
         case "w":
           e.preventDefault();
           if (selectedWsId) handleRemove(selectedWsId);
+          break;
+        case "f":
+          if (e.shiftKey && selectedWsId) {
+            e.preventDefault();
+            showSearchModal = true;
+          }
           break;
         default:
           if (!inInput && e.key >= "1" && e.key <= "9") {
@@ -373,7 +383,8 @@
         try {
           const content = await readWorkspaceFile(wsId, mention.path);
           const lines = content.split("\n").length;
-          contextBlocks.push(`<file path="${mention.path}" lines="${lines}" source="mention">\n${content}\n</file>`);
+          const focusAttr = mention.lineNumber ? ` focus_line="${mention.lineNumber}"` : "";
+          contextBlocks.push(`<file path="${mention.path}" lines="${lines}"${focusAttr} source="mention">\n${content}\n</file>`);
         } catch {
           // File unreadable (binary, too large, etc.) — just reference the path
           contextBlocks.push(`<file path="${mention.path}" source="mention">(could not read file — use Read tool to access)</file>`);
@@ -706,6 +717,7 @@
                     sendPrompt(ws.id, "Execute the plan above. Do not ask for confirmation — just do it.", "Executing plan");
                   }}
                   onMentionClick={(path) => { fileNavigatePath = path; activeTab = "files"; }}
+                  onReady={(api) => chatPanelApis.set(ws.id, api)}
                 />
               </div>
             {/each}
@@ -748,6 +760,23 @@
         {/if}
       </main>
     </div>
+
+    {#if showSearchModal && selectedWsId}
+      <SearchModal
+        workspaceId={selectedWsId}
+        onClose={() => { showSearchModal = false; }}
+        onAddToContext={(path, displayName, lineNumber) => {
+          showSearchModal = false;
+          chatPanelApis.get(selectedWsId!)?.addMention({ type: "file", path, displayName, lineNumber });
+          activeTab = "chat";
+        }}
+        onOpenInFiles={(path) => {
+          showSearchModal = false;
+          fileNavigatePath = path;
+          activeTab = "files";
+        }}
+      />
+    {/if}
 
     {#if showSettings}
       <RepoSettingsPanel


### PR DESCRIPTION
## Summary
- Adds a Telescope-style search modal (⌘⇧F) that greps workspace file contents via `rg --json`
- Split-pane UI: results list (left) with file preview and highlighted match line (right)
- Toggles for literal/regex mode (`.*`) and case sensitivity (`Aa`)
- Enter adds file as @mention context (with `focus_line` attribute), ⌘Enter opens in Files tab
- Async backend via `spawn_blocking` to keep UI responsive

## Test plan
- [ ] Open a workspace, press ⌘⇧F, type a query — results should appear
- [ ] Arrow keys navigate results, preview updates with highlighted line
- [ ] Press Enter — file added as mention chip in chat input with line number context
- [ ] Press ⌘Enter — switches to Files tab with the file open
- [ ] Toggle `.*` for regex, `Aa` for case sensitivity — results update accordingly
- [ ] Empty query, no matches, and invalid regex show appropriate states

🤖 Generated with [Claude Code](https://claude.com/claude-code)