### PR TITLE
feat: message queue — keep input enabled while agent runs

### DIFF
--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -33,13 +33,24 @@
     addMention: (mention: Mention) => void;
   }
 
+  export interface QueueDisplayItem {
+    id: string;
+    prompt: string;
+    imageCount: number;
+    mentionCount: number;
+    planMode: boolean;
+  }
+
   interface Props {
     workspaceId: string;
     creating?: boolean;
     planMode?: boolean;
     thinkingMode?: boolean;
+    queue?: QueueDisplayItem[];
     onSend: (prompt: string, images: PastedImage[], mentions: Mention[], planMode: boolean) => void;
+    onSendImmediate?: (prompt: string) => void;
     onStop: () => void;
+    onRemoveFromQueue?: (id: string) => void;
     onPlanModeChange?: (enabled: boolean) => void;
     onThinkingModeChange?: (enabled: boolean) => void;
     onExecutePlan?: () => void;
@@ -47,7 +58,7 @@
     onReady?: (api: ChatPanelApi) => void;
   }
 
-  let { workspaceId, creating = false, planMode = false, thinkingMode = false, onSend, onStop, onPlanModeChange, onThinkingModeChange, onExecutePlan, onMentionClick, onReady }: Props = $props();
+  let { workspaceId, creating = false, planMode = false, thinkingMode = false, queue = [], onSend, onSendImmediate, onStop, onRemoveFromQueue, onPlanModeChange, onThinkingModeChange, onExecutePlan, onMentionClick, onReady }: Props = $props();
 
   /** Split text into segments, replacing @displayName with mention references. */
   type TextSegment = { kind: "text"; value: string } | { kind: "mention"; mention: MessageMention };
@@ -263,13 +274,15 @@
     submittedBatches.add(batchKey);
 
     if (totalInBatch === 1) {
-      onSend(answers.get(0)!, [], [], false);
+      const answer = answers.get(0)!;
+      onSendImmediate ? onSendImmediate(answer) : onSend(answer, [], [], false);
     } else {
       const parts: string[] = [];
       for (let i = 0; i < totalInBatch; i++) {
         parts.push(`${i + 1}. ${answers.get(i) ?? "(no answer)"}`);
       }
-      onSend(parts.join("\n"), [], [], false);
+      const answer = parts.join("\n");
+      onSendImmediate ? onSendImmediate(answer) : onSend(answer, [], [], false);
     }
   }
 
@@ -378,7 +391,7 @@
   });
 
   function handleMentionSubmit(value: MentionInputValue) {
-    if (sending || creating) return;
+    if (creating) return;
     if (!value.text.trim() && value.mentions.length === 0 && pastedImages.length === 0) return;
     const prompt = value.text.trim();
     const images = [...pastedImages];
@@ -833,6 +846,36 @@
     {/if}
   </div>
 
+  {#if queue.length > 0}
+    <div class="queue-strip">
+      <span class="queue-label">Queued ({queue.length})</span>
+      <div class="queue-items">
+        {#each queue as item (item.id)}
+          <div class="queue-item">
+            <span class="queue-text">
+              {#if item.planMode}
+                <BookOpen size={11} strokeWidth={2} />
+              {/if}
+              {item.prompt.length > 80 ? item.prompt.slice(0, 80) + '…' : item.prompt}
+              {#if item.imageCount > 0}
+                <span class="queue-meta">{item.imageCount} img</span>
+              {/if}
+              {#if item.mentionCount > 0}
+                <span class="queue-meta">{item.mentionCount} file{item.mentionCount > 1 ? 's' : ''}</span>
+              {/if}
+            </span>
+            <button
+              type="button"
+              class="queue-remove"
+              onclick={() => onRemoveFromQueue?.(item.id)}
+              title="Remove from queue"
+            >&times;</button>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="input-form" onkeydown={handleInputKeydown} bind:this={inputEl}>
     {#if pastedImages.length > 0}
@@ -853,7 +896,7 @@
     {/if}
     <MentionInput
       placeholder={planMode ? "Describe what to analyze…" : "Ask to make changes, @mention files"}
-      disabled={creating || sending}
+      disabled={creating}
       onSubmit={handleMentionSubmit}
       onQueryChange={handleQueryChange}
       onPaste={handlePaste}
@@ -1828,6 +1871,73 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  /* ── Queue strip ────────── */
+
+  .queue-strip {
+    padding: 0.35rem 0.75rem;
+    background: color-mix(in srgb, var(--accent) 4%, var(--bg-card));
+    flex-shrink: 0;
+  }
+
+  .queue-label {
+    font-size: 0.68rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 500;
+  }
+
+  .queue-items {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    margin-top: 0.3rem;
+  }
+
+  .queue-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+  }
+
+  .queue-text {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .queue-meta {
+    font-size: 0.65rem;
+    color: var(--text-dim);
+    flex-shrink: 0;
+  }
+
+  .queue-remove {
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 1rem;
+    padding: 0 0.2rem;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+
+  .queue-remove:hover {
+    color: var(--diff-del, #e06c75);
   }
 
   /* ── Input (Slack-style container) ────────── */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,6 +68,23 @@
   let showSearchModal = $state(false);
   let chatPanelApis = new SvelteMap<string, ChatPanelApi>();
 
+  // ── Message queue ──────────────────────────────────────
+  interface QueuedMessage {
+    id: string;
+    prompt: string;        // raw user text (for display in queue UI)
+    fullPrompt: string;    // expanded prompt (with context blocks, image refs)
+    images: PastedImage[];
+    imageDataUrls?: string[];
+    mentions: Mention[];
+    msgMentions?: { type: "file" | "folder"; path: string; displayName: string }[];
+    planMode: boolean;
+    thinkingMode: boolean;
+    actionLabel?: string;
+  }
+  const queueByWorkspace = new SvelteMap<string, QueuedMessage[]>();
+  /** Set to true by Channel `done` event; checked by `agent-status: waiting` to trigger drain. */
+  const pendingDrain = new SvelteMap<string, boolean>();
+
   let selectedWs = $derived(workspaces.find((w) => w.id === selectedWsId));
   let activeWorkspaces = $derived(
     [...workspaces].sort((a, b) => a.created_at - b.created_at),
@@ -92,6 +109,10 @@
         }
         if (event.status === "waiting") {
           setSending(event.workspace_id, false);
+          if (pendingDrain.get(event.workspace_id)) {
+            pendingDrain.delete(event.workspace_id);
+            drainQueue(event.workspace_id);
+          }
         }
       });
 
@@ -276,6 +297,8 @@
     if (creatingWsId === wsId) creatingWsId = null;
     clearWorkspaceData(wsId);
     sendingByWorkspace.delete(wsId);
+    queueByWorkspace.delete(wsId);
+    pendingDrain.delete(wsId);
     prStatusMap.delete(wsId);
     changeCounts.delete(wsId);
     planModeByWorkspace.delete(wsId);
@@ -288,19 +311,21 @@
     });
   }
 
-  async function sendPrompt(wsId: string, prompt: string, actionLabel?: string) {
-    if (sendingByWorkspace.get(wsId)) return;
+  // ── Send pipeline ───────────────────────────────────────
+
+  /** Core send — assumes caller has verified it's safe to send. */
+  async function sendDirect(wsId: string, msg: QueuedMessage) {
     error = "";
     setSending(wsId, true);
 
-    if (actionLabel) {
-      addActionMessage(wsId, crypto.randomUUID(), actionLabel);
+    if (msg.actionLabel) {
+      addActionMessage(wsId, crypto.randomUUID(), msg.actionLabel);
     } else {
-      addUserMessage(wsId, crypto.randomUUID(), prompt);
+      addUserMessage(wsId, crypto.randomUUID(), msg.prompt || "(images attached)", msg.imageDataUrls, msg.msgMentions, msg.planMode || undefined);
     }
 
     try {
-      await sendMessage(wsId, prompt, (event: AgentEvent) => {
+      await sendMessage(wsId, msg.fullPrompt, (event: AgentEvent) => {
         if (event.type === "assistant_message") {
           const toolUses = event.tool_uses.map((t) => ({
             name: t.name,
@@ -324,8 +349,6 @@
           diffRefreshTrigger++;
           refreshChangeCounts(wsId);
           refreshPrStatus(wsId);
-          // Refresh workspace list to pick up any branch renames from MCP.
-          // Merge in-place instead of replacing the array to preserve granular reactivity.
           if (activeRepo) {
             listWorkspaces(activeRepo.id)
               .then((fresh) => {
@@ -338,7 +361,6 @@
                     workspaces.push(fw);
                   }
                 }
-                // Remove stale entries (removed externally), but keep the placeholder
                 for (let i = workspaces.length - 1; i >= 0; i--) {
                   if (!freshIds.has(workspaces[i].id) && workspaces[i].id !== creatingWsId) {
                     workspaces.splice(i, 1);
@@ -347,15 +369,69 @@
               })
               .catch(() => {});
           }
+          pendingDrain.set(wsId, true);
         } else if (event.type === "error") {
           error = event.message;
           setSending(wsId, false);
+          pendingDrain.delete(wsId);
         }
-      });
+      }, msg.planMode, msg.thinkingMode);
     } catch (e) {
       error = String(e);
       setSending(wsId, false);
+      pendingDrain.delete(wsId);
     }
+  }
+
+  /** Shift next queued message and send it. */
+  function drainQueue(wsId: string) {
+    const queue = queueByWorkspace.get(wsId);
+    if (!queue || queue.length === 0) return;
+    const next = queue.shift()!;
+    queueByWorkspace.set(wsId, [...queue]);
+    sendDirect(wsId, next);
+  }
+
+  /** Remove a specific message from the queue. */
+  function removeFromQueue(wsId: string, messageId: string) {
+    const queue = queueByWorkspace.get(wsId);
+    if (!queue) return;
+    queueByWorkspace.set(wsId, queue.filter(q => q.id !== messageId));
+  }
+
+  /** Route a QueuedMessage: send directly, or enqueue if busy. */
+  function routeMessage(wsId: string, msg: QueuedMessage) {
+    if (sendingByWorkspace.get(wsId)) {
+      // Agent busy → enqueue
+      const queue = queueByWorkspace.get(wsId) ?? [];
+      queue.push(msg);
+      queueByWorkspace.set(wsId, [...queue]);
+      return;
+    }
+    if ((queueByWorkspace.get(wsId)?.length ?? 0) > 0) {
+      // Idle but queue exists (e.g. after stop) → enqueue + drain
+      const queue = queueByWorkspace.get(wsId)!;
+      queue.push(msg);
+      queueByWorkspace.set(wsId, [...queue]);
+      drainQueue(wsId);
+      return;
+    }
+    // Idle, no queue → send directly
+    sendDirect(wsId, msg);
+  }
+
+  async function sendPrompt(wsId: string, prompt: string, actionLabel?: string) {
+    const thinkingMode = thinkingModeByWorkspace.get(wsId) ?? repoSettings?.default_thinking ?? false;
+    routeMessage(wsId, {
+      id: crypto.randomUUID(),
+      prompt,
+      fullPrompt: prompt,
+      images: [],
+      mentions: [],
+      planMode: false,
+      thinkingMode,
+      actionLabel,
+    });
   }
 
   async function handleSend(prompt: string, images: PastedImage[] = [], mentions: Mention[] = [], planMode: boolean = false) {
@@ -386,11 +462,9 @@
           const focusAttr = mention.lineNumber ? ` focus_line="${mention.lineNumber}"` : "";
           contextBlocks.push(`<file path="${mention.path}" lines="${lines}"${focusAttr} source="mention">\n${content}\n</file>`);
         } catch {
-          // File unreadable (binary, too large, etc.) — just reference the path
           contextBlocks.push(`<file path="${mention.path}" source="mention">(could not read file — use Read tool to access)</file>`);
         }
       } else if (mention.type === "folder") {
-        // For folders, just mention the path — Claude can explore it
         contextBlocks.push(`<folder path="${mention.path}" />`);
       }
     }
@@ -412,67 +486,36 @@
         : imageInstructions;
     }
 
-    // Add to message store with image paths for display
-    if (sendingByWorkspace.get(wsId)) return;
-    error = "";
-    setSending(wsId, true);
     const dataUrls = images.length > 0 ? images.map((img) => img.dataUrl) : undefined;
     const msgMentions = mentions.length > 0 ? mentions.map((m) => ({ type: m.type, path: m.path, displayName: m.displayName })) : undefined;
-    addUserMessage(wsId, crypto.randomUUID(), prompt || "(images attached)", dataUrls, msgMentions, planMode || undefined);
 
-    try {
-      await sendMessage(wsId, fullPrompt, (event: AgentEvent) => {
-        if (event.type === "assistant_message") {
-          const toolUses = event.tool_uses.map((t) => ({
-            name: t.name,
-            input: t.input_preview ?? "",
-            filePath: t.file_path,
-            oldString: t.old_string,
-            newString: t.new_string,
-          }));
-          addAssistantMessage(
-            wsId,
-            crypto.randomUUID(),
-            event.text.trim(),
-            toolUses,
-          );
-          if (event.tool_uses.length > 0) {
-            diffRefreshTrigger++;
-          }
-        } else if (event.type === "done") {
-          setSending(wsId, false);
-          diffRefreshTrigger++;
-          refreshChangeCounts(wsId);
-          refreshPrStatus(wsId);
-          if (activeRepo) {
-            listWorkspaces(activeRepo.id)
-              .then((fresh) => {
-                const freshIds = new Set(fresh.map((w) => w.id));
-                for (const fw of fresh) {
-                  const idx = workspaces.findIndex((w) => w.id === fw.id);
-                  if (idx >= 0) {
-                    workspaces[idx] = fw;
-                  } else {
-                    workspaces.push(fw);
-                  }
-                }
-                for (let i = workspaces.length - 1; i >= 0; i--) {
-                  if (!freshIds.has(workspaces[i].id) && workspaces[i].id !== creatingWsId) {
-                    workspaces.splice(i, 1);
-                  }
-                }
-              })
-              .catch(() => {});
-          }
-        } else if (event.type === "error") {
-          error = event.message;
-          setSending(wsId, false);
-        }
-      }, planMode, thinkingMode);
-    } catch (e) {
-      error = String(e);
-      setSending(wsId, false);
-    }
+    routeMessage(wsId, {
+      id: crypto.randomUUID(),
+      prompt,
+      fullPrompt,
+      images,
+      imageDataUrls: dataUrls,
+      mentions,
+      msgMentions,
+      planMode,
+      thinkingMode,
+    });
+  }
+
+  /** Send immediately, bypassing the queue. Used for AskUserQuestion answers. */
+  async function handleSendImmediate(prompt: string) {
+    if (!selectedWsId) return;
+    const wsId = selectedWsId;
+    const thinkingMode = thinkingModeByWorkspace.get(wsId) ?? repoSettings?.default_thinking ?? false;
+    sendDirect(wsId, {
+      id: crypto.randomUUID(),
+      prompt,
+      fullPrompt: prompt,
+      images: [],
+      mentions: [],
+      planMode: false,
+      thinkingMode,
+    });
   }
 
   async function handleRename(wsId: string, newName: string) {
@@ -708,8 +751,17 @@
                   creating={ws.id === creatingWsId}
                   planMode={planModeByWorkspace.get(ws.id) ?? repoSettings?.default_plan ?? false}
                   thinkingMode={thinkingModeByWorkspace.get(ws.id) ?? repoSettings?.default_thinking ?? false}
+                  queue={(queueByWorkspace.get(ws.id) ?? []).map(q => ({
+                    id: q.id,
+                    prompt: q.prompt,
+                    imageCount: q.images.length,
+                    mentionCount: q.mentions.length,
+                    planMode: q.planMode,
+                  }))}
                   onSend={(prompt, images, mentions, planMode) => handleSend(prompt, images, mentions, planMode)}
+                  onSendImmediate={(prompt) => handleSendImmediate(prompt)}
                   onStop={handleStop}
+                  onRemoveFromQueue={(id) => { if (ws.id) removeFromQueue(ws.id, id); }}
                   onPlanModeChange={(enabled) => planModeByWorkspace.set(ws.id, enabled)}
                   onThinkingModeChange={(enabled) => thinkingModeByWorkspace.set(ws.id, enabled)}
                   onExecutePlan={() => {


### PR DESCRIPTION
## Summary
- Input stays enabled while the agent is processing — submitting enqueues messages that auto-send on completion
- Queue strip shown above input with per-item remove buttons
- Deduplicated send logic into `sendDirect`/`routeMessage` pipeline, fixing done-handler duplication between `handleSend` and `sendPrompt`
- AskUserQuestion answers bypass the queue via `onSendImmediate` to avoid ordering issues
- Queue drains on `agent-status: waiting` event (not Channel `done`) to avoid race condition with Rust agent cleanup

## Test plan
- [ ] Send message → while agent runs, type + send 2 more → verify queue strip appears with items
- [ ] Verify queued messages auto-send sequentially after agent completes
- [ ] Click × on a queued item → verify removal
- [ ] Stop agent with items queued → send new message → verify queue resumes
- [ ] Trigger AskUserQuestion → answer → verify answer sends immediately, not queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)