### PR TITLE
feat: add per-repo system prompt injection

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1818,7 +1818,7 @@ pub fn send_message(
 ) -> Result<(), String> {
     let plan_mode = plan_mode.unwrap_or(false);
     let thinking_mode = thinking_mode.unwrap_or(false);
-    let (worktree_path, gh_profile, repo_id, ws_branch, repo_path) = {
+    let (worktree_path, gh_profile, repo_id, ws_branch, repo_path, user_system_prompt) = {
         let st = state.lock().map_err(|e| e.to_string())?;
         if st.agents.contains_key(&workspace_id) {
             return Err("Agent is already processing a message".into());
@@ -1828,12 +1828,17 @@ pub fn send_message(
             .get(&workspace_id)
             .ok_or("Workspace not found")?;
         let repo = st.repos.get(&ws.repo_id).ok_or("Repo not found")?;
+        let user_sp = st.repo_settings
+            .get(&ws.repo_id)
+            .map(|s| s.system_prompt.clone())
+            .unwrap_or_default();
         (
             ws.worktree_path.clone(),
             repo.gh_profile.clone(), // Always use repo's current profile, not stale workspace snapshot
             ws.repo_id.clone(),
             ws.branch.clone(),
             repo.path.clone(),
+            user_sp,
         )
     };
 
@@ -1933,7 +1938,7 @@ pub fn send_message(
         // Inject system prompt only on first message (resume inherits it)
         let base_branch = detect_default_branch(&repo_path)
             .unwrap_or_else(|_| "main".to_string());
-        let system_prompt = format!(
+        let mut system_prompt = format!(
             "You are working inside Korlap, a Mac app that runs coding agents in parallel.\n\
              Your working directory is already set to the workspace. Do not cd into it — you are already there.\n\
              Target branch: {}\n\
@@ -1945,6 +1950,10 @@ pub fn send_message(
             ws_branch,
             base_branch,
         );
+        if !user_system_prompt.is_empty() {
+            system_prompt.push_str("\n\nUser preferences:\n");
+            system_prompt.push_str(&user_system_prompt);
+        }
         cmd.arg("--system-prompt").arg(&system_prompt);
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -48,6 +48,8 @@ pub struct RepoSettings {
     pub default_thinking: bool,
     #[serde(default)]
     pub default_plan: bool,
+    #[serde(default)]
+    pub system_prompt: String,
 }
 
 pub struct TerminalHandle {

--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -29,6 +29,7 @@
     pr_message: "",
     default_thinking: false,
     default_plan: false,
+    system_prompt: "",
   });
   let saveStatus = $state<"idle" | "saving" | "saved">("idle");
   let saveTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -184,6 +185,21 @@
         <span class="autosave-status" class:visible={saveStatus !== "idle"}>
           {saveStatus === "saving" ? "Saving..." : "Saved"}
         </span>
+      </div>
+
+      <div class="setting-block">
+        <div class="setting-meta">
+          <span class="setting-name">System prompt</span>
+          <span class="setting-desc">Custom instructions injected into every new conversation. Applied to all workspaces in this repo.</span>
+        </div>
+        <textarea
+          class="system-prompt-field"
+          bind:value={settings.system_prompt}
+          oninput={scheduleAutosave}
+          placeholder="- Never handwave errors or warnings&#10;- Debug log early to verify your assumption&#10;- Search the internet before guessing"
+          rows="6"
+          spellcheck="false"
+        ></textarea>
       </div>
 
       <div class="setting-block">
@@ -605,6 +621,29 @@
   .toggle-switch.on .toggle-knob {
     transform: translateX(16px);
     background: var(--accent);
+  }
+
+  .system-prompt-field {
+    width: 100%;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    padding: 0.6rem 0.65rem;
+    resize: vertical;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .system-prompt-field::placeholder {
+    color: var(--text-muted);
+  }
+
+  .system-prompt-field:focus {
+    border-color: var(--border-light);
   }
 
   .pr-message-field {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -318,6 +318,7 @@ export interface RepoSettings {
   pr_message: string;
   default_thinking: boolean;
   default_plan: boolean;
+  system_prompt: string;
 }
 
 export async function getRepoSettings(repoId: string): Promise<RepoSettings> {


### PR DESCRIPTION
## Summary
- Adds a "System prompt" textarea to the Agent tab in repo settings
- User preferences are injected into `--system-prompt` on new sessions (resume inherits)
- Repo-level setting — applies to all workspaces in the repo, persisted in `repo_settings.json`

## Test plan
- [ ] Open repo settings → Agent tab → verify "System prompt" textarea appears
- [ ] Enter preferences, switch tabs, return — verify auto-save persists
- [ ] Start a new workspace conversation — verify preferences appear in agent's system prompt
- [ ] Resume an existing session — verify preferences are NOT re-injected (inherited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)