### PR TITLE
feat: add collapsible sidebar groups

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { WorkspaceInfo, PrStatus } from "$lib/ipc";
   import { Eye, ChevronRight } from "lucide-svelte";
+  import { SvelteSet } from "svelte/reactivity";
 
   interface Props {
     workspaces: WorkspaceInfo[];
@@ -63,13 +64,13 @@
     ];
   });
 
-  let collapsedGroups = $state(new Set<GroupKey>(["done"]));
+  const collapsed = new SvelteSet<GroupKey>(["done"]);
 
   function toggleGroup(key: GroupKey) {
-    if (collapsedGroups.has(key)) {
-      collapsedGroups.delete(key);
+    if (collapsed.has(key)) {
+      collapsed.delete(key);
     } else {
-      collapsedGroups.add(key);
+      collapsed.add(key);
     }
   }
 
@@ -106,13 +107,13 @@
     {#each groups as group}
       <div class="group">
         <button class="group-header" onclick={() => toggleGroup(group.key)}>
-          <span class="group-chevron" class:expanded={!collapsedGroups.has(group.key)}>
+          <span class="group-chevron" class:expanded={!collapsed.has(group.key)}>
             <ChevronRight size={12} />
           </span>
           <span class="group-label">{group.label}</span>
           <span class="group-count">{group.items.length}</span>
         </button>
-        {#if !collapsedGroups.has(group.key)}
+        {#if !collapsed.has(group.key)}
         {#each group.items as ws (ws.id)}
           <div class="ws-item-wrap">
             <button
@@ -185,18 +186,18 @@
   .workspace-list {
     flex: 1;
     overflow-y: auto;
-    padding: 0.25rem;
+    padding: 0.25rem 0;
   }
 
   .group + .group {
-    margin-top: 0.4rem;
+    border-top: 1px solid var(--border);
   }
 
   .group-header {
     display: flex;
     align-items: center;
-    gap: 0.3rem;
-    padding: 0.35rem 0.5rem 0.2rem;
+    gap: 0.25rem;
+    padding: 0.3rem 0.5rem 0.25rem;
     width: 100%;
     background: transparent;
     border: none;
@@ -213,6 +214,7 @@
     display: flex;
     align-items: center;
     color: var(--text-dim);
+    opacity: 0.5;
     transition: transform 0.15s ease;
     transform: rotate(0deg);
   }
@@ -222,17 +224,17 @@
   }
 
   .group-label {
-    font-size: 0.65rem;
+    font-size: 0.7rem;
     color: var(--text-dim);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    font-weight: 500;
+    font-weight: 600;
   }
 
   .group-count {
     font-size: 0.6rem;
     color: var(--text-dim);
-    opacity: 0.6;
+    opacity: 0.45;
   }
 
   .ws-item-wrap {


### PR DESCRIPTION
## Summary
- Sidebar group headers (Ready, Review, Done) are now clickable to collapse/expand their workspace lists
- Adds a rotating chevron indicator for visual feedback
- Done group defaults to collapsed to reduce sidebar clutter

## Test plan
- [ ] Click group headers to toggle collapse/expand
- [ ] Verify chevron rotates on toggle
- [ ] Confirm Done group starts collapsed on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)