### PR TITLE
fix: embed ripgrep as library instead of spawning external binary

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -320,6 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -934,6 +935,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1511,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "grep-matcher"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,10 +2090,14 @@ dependencies = [
  "base64 0.22.1",
  "cocoa",
  "fuzzy-matcher",
+ "grep-matcher",
+ "grep-regex",
+ "grep-searcher",
  "ignore",
  "objc",
  "portable-pty",
  "rand 0.8.5",
+ "regex",
  "serde",
  "serde_json",
  "tauri",
@@ -2211,6 +2271,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,10 @@ portable-pty = "0.8"
 base64 = "0.22"
 ignore = "0.4"
 fuzzy-matcher = "0.3"
+grep-regex = "0.1"
+grep-searcher = "0.1"
+grep-matcher = "0.1"
+regex = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1381,100 +1381,132 @@ pub async fn grep_workspace(
     }
 
     let wt = worktree_path.clone();
-    let output = tauri::async_runtime::spawn_blocking(move || {
-        let mut cmd = std::process::Command::new("rg");
-        cmd.arg("--json")
-            .arg(if case_sensitive { "--case-sensitive" } else { "--smart-case" })
-            .arg("--max-count=5")
-            .arg("--max-columns=500")
-            .arg("--max-filesize=1M");
+    tauri::async_runtime::spawn_blocking(move || {
+        use grep_matcher::Matcher;
+        use grep_regex::RegexMatcherBuilder;
+        use grep_searcher::sinks::UTF8;
+        use grep_searcher::SearcherBuilder;
+        use ignore::WalkBuilder;
 
-        if !is_regex {
-            cmd.arg("--fixed-strings");
+        // Build the regex matcher with the same semantics as `rg`
+        let escaped_pattern = if is_regex {
+            pattern_trimmed.clone()
+        } else {
+            regex::escape(&pattern_trimmed)
+        };
+
+        let mut builder = RegexMatcherBuilder::new();
+        if case_sensitive {
+            // Strict case: defaults are fine (case_insensitive=false, case_smart=false)
+        } else {
+            // Smart case: case-insensitive unless pattern has uppercase
+            builder.case_smart(true);
+        }
+        let matcher = builder
+            .build(&escaped_pattern)
+            .map_err(|e| format!("Invalid pattern: {}", e))?;
+
+        let mut searcher = SearcherBuilder::new()
+            .line_number(true)
+            .build();
+
+        let max_results: usize = 100;
+        let max_matches_per_file: usize = 5;
+        let max_line_len: usize = 500;
+        let max_filesize: u64 = 1_048_576; // 1MB
+
+        let mut results: Vec<GrepMatch> = Vec::new();
+        let mut truncated = false;
+        let worktree_prefix = wt.to_string_lossy().to_string();
+
+        let walker = WalkBuilder::new(&wt)
+            .hidden(true) // respect hidden files like rg default (skip .hidden)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .max_filesize(Some(max_filesize))
+            .build();
+
+        'outer: for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            // Skip directories and symlinks
+            let ft = match entry.file_type() {
+                Some(ft) => ft,
+                None => continue,
+            };
+            if !ft.is_file() {
+                continue;
+            }
+
+            let path = entry.path().to_path_buf();
+
+            let mut file_match_count = 0usize;
+
+            let search_result = searcher.search_path(
+                &matcher,
+                &path,
+                UTF8(|line_number, line_content| {
+                    if results.len() >= max_results {
+                        truncated = true;
+                        return Ok(false); // stop searching
+                    }
+                    if file_match_count >= max_matches_per_file {
+                        return Ok(false); // stop this file
+                    }
+                    file_match_count += 1;
+
+                    let raw_path = path.to_string_lossy();
+                    let rel_path = raw_path
+                        .strip_prefix(&worktree_prefix)
+                        .unwrap_or(&raw_path)
+                        .trim_start_matches('/');
+
+                    // Find column of first match in the line
+                    let column = matcher
+                        .find(line_content.as_bytes())
+                        .ok()
+                        .flatten()
+                        .map(|m| m.start() as u32)
+                        .unwrap_or(0);
+
+                    let mut content = line_content.trim_end().to_string();
+                    if content.len() > max_line_len {
+                        content.truncate(max_line_len);
+                        content.push_str("…");
+                    }
+
+                    results.push(GrepMatch {
+                        path: rel_path.to_string(),
+                        line_number: line_number as u32,
+                        column,
+                        line_content: content,
+                    });
+
+                    Ok(true)
+                }),
+            );
+
+            // Silently skip files that can't be searched (binary, encoding issues, etc.)
+            if let Err(_) = search_result {
+                continue;
+            }
+
+            if truncated {
+                break 'outer;
+            }
         }
 
-        cmd.arg("--").arg(&pattern_trimmed).current_dir(&wt);
-        cmd.output()
+        Ok(GrepResult {
+            matches: results,
+            truncated,
+        })
     })
     .await
     .map_err(|e| e.to_string())?
-    .map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            "ripgrep (rg) not found — install via 'brew install ripgrep'".to_string()
-        } else {
-            format!("Failed to run rg: {}", e)
-        }
-    })?;
-
-    // Exit code 1 = no matches (not an error), 2 = regex error or similar
-    if !output.status.success() && output.status.code() != Some(1) {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("rg error: {}", stderr.trim()));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut matches = Vec::new();
-    let mut truncated = false;
-    let max_results = 100;
-
-    let worktree_prefix = worktree_path.to_string_lossy();
-
-    for line in stdout.lines() {
-        if matches.len() >= max_results {
-            truncated = true;
-            break;
-        }
-
-        let parsed: serde_json::Value = match serde_json::from_str(line) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-
-        if parsed.get("type").and_then(|t| t.as_str()) != Some("match") {
-            continue;
-        }
-
-        let data = match parsed.get("data") {
-            Some(d) => d,
-            None => continue,
-        };
-
-        let raw_path = data
-            .pointer("/path/text")
-            .and_then(|p| p.as_str())
-            .unwrap_or("");
-        // Make path relative to worktree
-        let rel_path = raw_path
-            .strip_prefix(worktree_prefix.as_ref())
-            .unwrap_or(raw_path)
-            .trim_start_matches('/');
-
-        let line_number = data
-            .get("line_number")
-            .and_then(|n| n.as_u64())
-            .unwrap_or(0) as u32;
-
-        let line_content = data
-            .pointer("/lines/text")
-            .and_then(|t| t.as_str())
-            .unwrap_or("")
-            .trim_end()
-            .to_string();
-
-        let column = data
-            .pointer("/submatches/0/start")
-            .and_then(|s| s.as_u64())
-            .unwrap_or(0) as u32;
-
-        matches.push(GrepMatch {
-            path: rel_path.to_string(),
-            line_number,
-            column,
-            line_content,
-        });
-    }
-
-    Ok(GrepResult { matches, truncated })
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- Replaces the `rg` subprocess spawn in `grep_workspace` with in-process search using `grep-regex`, `grep-searcher`, and `grep-matcher` crates — the same engine that powers ripgrep.
- Fixes content search failing when the app is launched from Finder/Spotlight, since macOS GUI apps don't inherit the shell `PATH` where Homebrew binaries live.
- Zero frontend changes — same `GrepMatch`/`GrepResult` output format.

## Test plan
- [ ] Launch app from Finder (not CLI) and verify content search works
- [ ] Test literal search, regex search, case-sensitive toggle
- [ ] Verify `.gitignore` patterns are still respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)