### PR TITLE
feat: centralized keyboard shortcuts with repo switcher navigation

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -5,12 +5,19 @@
   interface Props {
     trigger: Snippet;
     children: Snippet;
+    onclose?: () => void;
   }
 
-  let { trigger, children }: Props = $props();
+  let { trigger, children, onclose }: Props = $props();
 
   let open = $state(false);
   let rootEl: HTMLDivElement | undefined = $state();
+  let prevOpen = false;
+
+  $effect(() => {
+    if (prevOpen && !open) onclose?.();
+    prevOpen = open;
+  });
 
   export function close() {
     open = false;

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -18,9 +18,10 @@
     onReview: () => void;
     reviewRunning: boolean;
     highlightedRepoIndex: number;
+    onDropdownClose?: () => void;
   }
 
-  let { repos, activeRepo, selectedWs, prStatus, wsChanges, onSelectRepo, onAddRepo, onSettings, onPrAction, onReview, reviewRunning, highlightedRepoIndex }: Props =
+  let { repos, activeRepo, selectedWs, prStatus, wsChanges, onSelectRepo, onAddRepo, onSettings, onPrAction, onReview, reviewRunning, highlightedRepoIndex, onDropdownClose }: Props =
     $props();
 
   let dropdownRef: Dropdown | undefined = $state();
@@ -72,7 +73,7 @@
 >
   <div class="titlebar-left">
     <div class="btn-group">
-      <Dropdown bind:this={dropdownRef}>
+      <Dropdown bind:this={dropdownRef} onclose={onDropdownClose}>
         {#snippet trigger()}
           <span class="repo-name">{activeRepo.display_name}</span>
           <kbd class="shortcut-hint">⌘E</kbd>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -918,6 +918,7 @@ No need to mention in your report whether or not you used one of the fallback st
       {repos}
       {activeRepo}
       highlightedRepoIndex={repoDropdownIndex}
+      onDropdownClose={() => (repoDropdownIndex = -1)}
       {selectedWs}
       prStatus={selectedWsId ? prStatusMap.get(selectedWsId) : undefined}
       wsChanges={selectedWsId ? changeCounts.get(selectedWsId) : undefined}


### PR DESCRIPTION
## Summary
- Consolidate all global keyboard shortcuts into a single `handleKeydown` in `+page.svelte` (previously split across TitleBar and page)
- Add `⌘E` to toggle the repo switcher dropdown, with arrow key navigation, Enter to select, and `1–9` for direct repo access
- Show shortcut hint pill (`⌘E`) on the dropdown trigger and number pills on each repo item
- Arrow navigation extends to the "Add repository" option

## Test plan
- [ ] Press `⌘E` to open/close the repo switcher dropdown
- [ ] Use `↑`/`↓` to navigate repos including "Add repository"
- [ ] Press `Enter` to select highlighted repo or trigger "Add repository"
- [ ] Press `1`–`9` to directly switch repos while dropdown is open
- [ ] Verify existing shortcuts (`⌘,`, `⌘N`, `⌘W`, `⌘⇧F`, `⌘1-9`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)