### PR TITLE
fix: save pasted images to app data dir instead of worktree

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1815,8 +1815,9 @@ pub fn load_messages(
 
 // ── Image commands ───────────────────────────────────────────────────
 
-/// Save base64-encoded image data to a file in the workspace directory.
+/// Save base64-encoded image data to the app data directory.
 /// Returns the absolute path to the saved image.
+/// Images are stored under `<data_dir>/images/<workspace_id>/` — never in the worktree.
 #[tauri::command]
 pub fn save_image(
     workspace_id: String,
@@ -1824,13 +1825,9 @@ pub fn save_image(
     extension: String,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<String, String> {
-    let worktree_path = {
+    let images_dir = {
         let st = state.lock().map_err(|e| e.to_string())?;
-        let ws = st
-            .workspaces
-            .get(&workspace_id)
-            .ok_or("Workspace not found")?;
-        ws.worktree_path.clone()
+        st.data_dir.join("images").join(&workspace_id)
     };
 
     // Decode base64
@@ -1839,29 +1836,8 @@ pub fn save_image(
         .decode(&data)
         .map_err(|e| format!("Invalid base64 data: {}", e))?;
 
-    // Save to .korlap-images/ inside the worktree (gitignored by convention)
-    let images_dir = worktree_path.join(".korlap-images");
     std::fs::create_dir_all(&images_dir)
         .map_err(|e| format!("Failed to create images dir: {}", e))?;
-
-    // Ensure .korlap-images is gitignored
-    let gitignore_path = worktree_path.join(".gitignore");
-    let needs_entry = if gitignore_path.exists() {
-        let content = std::fs::read_to_string(&gitignore_path).unwrap_or_default();
-        !content.lines().any(|l| l.trim() == ".korlap-images/")
-    } else {
-        true
-    };
-    if needs_entry {
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&gitignore_path)
-            .map_err(|e| format!("Failed to update .gitignore: {}", e))?;
-        use std::io::Write;
-        writeln!(file, "\n.korlap-images/")
-            .map_err(|e| format!("Failed to write .gitignore: {}", e))?;
-    }
 
     let ext = if extension.is_empty() { "png" } else { &extension };
     let filename = format!("{}.{}", Uuid::new_v4(), ext);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -195,10 +195,11 @@ impl AppState {
         self.data_dir.join("messages")
     }
 
-    /// Delete all persisted data for a workspace (messages file, session entry).
+    /// Delete all persisted data for a workspace (messages file, session entry, images).
     /// Call this when permanently removing a workspace.
     pub fn delete_workspace_data(&mut self, workspace_id: &str) {
         let _ = std::fs::remove_file(self.messages_dir().join(format!("{}.json", workspace_id)));
+        let _ = std::fs::remove_dir_all(self.data_dir.join("images").join(workspace_id));
         self.session_ids.remove(workspace_id);
     }
 


### PR DESCRIPTION
## Summary
- Pasted images were saved to `.korlap-images/` inside the git worktree, polluting the user's repo and mutating `.gitignore`
- Now saves to `<data_dir>/images/<workspace_id>/` (app data dir) — zero files written to managed repos
- Images directory is cleaned up when a workspace is deleted

## Test plan
- [ ] Paste an image in chat input, verify it saves under `~/Library/Application Support/net.ghora.korlap/images/`
- [ ] Verify no `.korlap-images/` dir or `.gitignore` changes appear in the worktree
- [ ] Delete a workspace, verify its images directory is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)