### PR TITLE
fix: disable toolbar action buttons during busy state

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -24,6 +24,8 @@
   let { repos, activeRepo, selectedWs, prStatus, wsChanges, onSelectRepo, onAddRepo, onSettings, onPrAction, onReview, reviewRunning, highlightedRepoIndex, onDropdownClose }: Props =
     $props();
 
+  let isBusy = $derived(selectedWs?.status === "running" || reviewRunning);
+
   let dropdownRef: Dropdown | undefined = $state();
 
   function selectRepo(repo: RepoDetail) {
@@ -128,27 +130,27 @@
           <button class="pr-link-btn" onclick={() => openUrl(prStatus!.url)} title="Open PR #{prStatus.number} in browser">
             <ExternalLink size={12} />
           </button>
-          <button class="action-badge review" onclick={onReview} disabled={selectedWs.status === "running" || reviewRunning}>
+          <button class="action-badge review" onclick={onReview} disabled={isBusy}>
             <Eye size={11} /> Review
           </button>
           {#if prStatus.mergeable === "conflicting"}
-            <button class="action-badge conflicts" onclick={onPrAction}><AlertTriangle size={11} /> Conflicts</button>
+            <button class="action-badge conflicts" onclick={onPrAction} disabled={isBusy}><AlertTriangle size={11} /> Conflicts</button>
           {:else if prStatus.checks === "failing"}
-            <button class="action-badge checks-fail" onclick={onPrAction}><Wrench size={11} /> Fix issues</button>
+            <button class="action-badge checks-fail" onclick={onPrAction} disabled={isBusy}><Wrench size={11} /> Fix issues</button>
           {:else if prStatus.checks === "pending"}
             <span class="status-label checks-pending"><Loader size={10} class="status-icon spinning" /> Checks pending</span>
           {:else if (prStatus.ahead_by ?? 0) > 0}
-            <button class="action-badge push-needed" onclick={onPrAction}><ArrowUp size={11} /> Push</button>
+            <button class="action-badge push-needed" onclick={onPrAction} disabled={isBusy}><ArrowUp size={11} /> Push</button>
           {:else if wsChanges && (wsChanges.additions !== prStatus.additions || wsChanges.deletions !== prStatus.deletions)}
-            <button class="action-badge push-needed" onclick={onPrAction}><ArrowUp size={11} /> Commit & push</button>
+            <button class="action-badge push-needed" onclick={onPrAction} disabled={isBusy}><ArrowUp size={11} /> Commit & push</button>
           {:else}
-            <button class="action-badge mergeable" onclick={onPrAction}><GitMerge size={11} /> Merge</button>
+            <button class="action-badge mergeable" onclick={onPrAction} disabled={isBusy}><GitMerge size={11} /> Merge</button>
           {/if}
         </div>
       {:else if prStatus?.state === "merged"}
         <span class="status-label merged"><Check size={10} class="status-icon" /> Done</span>
       {:else if wsChanges && (wsChanges.additions > 0 || wsChanges.deletions > 0)}
-        <button class="action-badge create-pr" onclick={onPrAction} disabled={selectedWs.status === "running"}><GitPullRequestCreate size={11} /> Push & create PR</button>
+        <button class="action-badge create-pr" onclick={onPrAction} disabled={isBusy}><GitPullRequestCreate size={11} /> Push & create PR</button>
       {/if}
     {/if}
   </div>
@@ -378,6 +380,12 @@
     border-radius: 0 4px 4px 0;
   }
 
+  .action-badge:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
   .action-badge.create-pr {
     color: var(--accent);
     border-color: color-mix(in srgb, var(--accent) 40%, transparent);
@@ -388,18 +396,13 @@
     filter: brightness(1.2);
   }
 
-  .action-badge.create-pr:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-  }
-
   .action-badge.push-needed {
     color: var(--accent);
     border-color: color-mix(in srgb, var(--accent) 40%, transparent);
     background: color-mix(in srgb, var(--accent) 7%, transparent);
   }
 
-  .action-badge.push-needed:hover {
+  .action-badge.push-needed:hover:not(:disabled) {
     filter: brightness(1.2);
   }
 
@@ -409,7 +412,7 @@
     background: color-mix(in srgb, var(--status-ok) 7%, transparent);
   }
 
-  .action-badge.mergeable:hover {
+  .action-badge.mergeable:hover:not(:disabled) {
     filter: brightness(1.2);
   }
 
@@ -419,7 +422,7 @@
     background: color-mix(in srgb, var(--diff-del) 7%, transparent);
   }
 
-  .action-badge.checks-fail:hover {
+  .action-badge.checks-fail:hover:not(:disabled) {
     filter: brightness(1.2);
   }
 
@@ -437,18 +440,13 @@
     background: var(--border);
   }
 
-  .action-badge.review:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-  }
-
   .action-badge.conflicts {
     color: #c87e7e;
     border-color: color-mix(in srgb, #c87e7e 40%, transparent);
     background: color-mix(in srgb, #c87e7e 7%, transparent);
   }
 
-  .action-badge.conflicts:hover {
+  .action-badge.conflicts:hover:not(:disabled) {
     filter: brightness(1.2);
   }
 


### PR DESCRIPTION
## Summary
- Merge, Conflicts, Fix issues, Push, and Commit & push buttons were still clickable while the agent was running or reviewing
- Added `disabled={isBusy}` to all toolbar action buttons using a single `$derived` (`isBusy = status === "running" || reviewRunning`)
- Consolidated duplicate disabled styles into a generic `.action-badge:disabled` rule and guarded all `:hover` selectors with `:not(:disabled)`

## Test plan
- [ ] Start an agent, verify all toolbar buttons (Merge, Push, Review, etc.) are visually dimmed and unclickable
- [ ] Trigger a review, verify buttons remain disabled until review completes
- [ ] External link button should remain clickable during busy state

🤖 Generated with [Claude Code](https://claude.com/claude-code)