### PR TITLE
fix: ChatPanel rendering perf with virtualization and state preservation

### DIFF
--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -5,6 +5,7 @@
   import { renderMarkdown } from "$lib/markdown";
   import MentionInput, { type Mention, type MentionInputValue, type MentionInputApi } from "./MentionInput.svelte";
   import MentionAutocomplete, { type MentionAutocompleteApi } from "./MentionAutocomplete.svelte";
+  import VirtualScroller from "./VirtualScroller.svelte";
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
 
   const toolIcons: Record<string, typeof Settings> = {
@@ -93,7 +94,8 @@
     return segments;
   }
 
-  let messages = $derived(messagesByWorkspace.get(workspaceId) ?? []);
+  let messagesMap = $derived(messagesByWorkspace.get(workspaceId));
+  let messages = $derived(messagesMap ? [...messagesMap.values()] : []);
   let sending = $derived(sendingByWorkspace.get(workspaceId) ?? false);
 
   // Elapsed timer for "thinking" indicator
@@ -121,7 +123,6 @@
   });
 
   let pastedImages = $state<PastedImage[]>([]);
-  let chatArea: HTMLDivElement | undefined = $state();
   let userScrolledUp = $state(false);
   let inputEl: HTMLDivElement | undefined = $state();
 
@@ -227,6 +228,7 @@
   }
 
   let visualBlocks = $derived(buildVisualBlocks(messages));
+
 
   // AskUserQuestion: multi-select toggles and custom input per question
   // qKey = "msgId:chunkIdx:questionIdx" — identifies a single question
@@ -335,21 +337,6 @@
   // Tracks the message count when user clicked Revise — hides plan actions until new messages arrive
   let planActionsHiddenAt = $state<number | null>(null);
 
-  function handleScroll(e: Event) {
-    const el = e.target as HTMLElement;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
-    userScrolledUp = !atBottom;
-  }
-
-  $effect(() => {
-    messages.length;
-    sending;
-    if (!userScrolledUp && chatArea) {
-      requestAnimationFrame(() => {
-        chatArea!.scrollTop = chatArea!.scrollHeight;
-      });
-    }
-  });
 
   // Show "Execute plan" button only when the most recent user-or-action message
   // is a plan-mode user message and Claude has responded after it.
@@ -389,6 +376,13 @@
     }
     return files;
   });
+
+  // Footer items (file pills, plan actions, thinking) rendered as a single
+  // extra item at the end of the virtual list so they scroll naturally.
+  let hasFooter = $derived(
+    (recentFiles.length > 0 && !sending) || showExecutePlan || sending,
+  );
+  let virtualCount = $derived(visualBlocks.length + (hasFooter ? 1 : 0));
 
   function handleMentionSubmit(value: MentionInputValue) {
     if (creating) return;
@@ -491,360 +485,374 @@
 </script>
 
 <div class="chat-panel">
-  <div class="chat-area" bind:this={chatArea} onscroll={handleScroll}>
-    {#if creating}
+  {#if creating}
+    <div class="chat-area-static">
       <div class="chat-empty">
         <div class="creating-spinner"></div>
         <p class="creating-text">Setting up workspace...</p>
       </div>
-    {:else if messages.length === 0 && !sending}
+    </div>
+  {:else if messages.length === 0 && !sending}
+    <div class="chat-area-static">
       <div class="chat-empty">
         <p>Send a message to start the agent.</p>
       </div>
-    {:else}
-      {#each visualBlocks as block, bi (block.key)}
-        {#if block.kind === "action"}
-          <div class="action-msg">
-            <span class="action-indicator">{block.msg.actionLabel ?? "Action"}</span>
-          </div>
-        {:else if block.kind === "user"}
-          <div class="user-msg">
-            {#if block.msg.imageDataUrls && block.msg.imageDataUrls.length > 0}
-              <div class="user-images">
-                {#each block.msg.imageDataUrls as dataUrl}
-                  <div class="user-image-thumb">
-                    <img src={dataUrl} alt="Attached" />
-                  </div>
-                {/each}
+    </div>
+  {:else}
+    <VirtualScroller
+      count={virtualCount}
+      estimatedHeight={60}
+      gap={10}
+      overscan={5}
+      stickToBottom={!userScrolledUp}
+      onscrolledUp={(v) => { userScrolledUp = v; }}
+    >
+      {#snippet children(index)}
+        {#if index < visualBlocks.length}
+          {@const block = visualBlocks[index]}
+          {@const bi = index}
+          <div class="virtual-block">
+            {#if block.kind === "action"}
+              <div class="action-msg">
+                <span class="action-indicator">{block.msg.actionLabel ?? "Action"}</span>
               </div>
-            {/if}
-            {#if block.msg.planMode}
-              <div class="plan-badge-row">
-                <span class="plan-badge">
-                  <BookOpen size={11} strokeWidth={2} />
-                  Plan
-                </span>
-              </div>
-            {/if}
-            <div class="user-bubble">
-              {#each block.msg.chunks as chunk}
-                {#if chunk.type === "text"}
-                  {#if block.msg.mentions && block.msg.mentions.length > 0}
-                    {#each splitTextWithMentions(chunk.content, block.msg.mentions) as seg}
-                      {#if seg.kind === "text"}{seg.value}{:else}
-                        <button
-                          class="msg-mention-chip"
-                          onclick={() => onMentionClick?.(seg.mention.path)}
-                        >@{seg.mention.displayName}</button>
-                      {/if}
-                    {/each}
-                  {:else}
-                    {chunk.content}
-                  {/if}
-                {/if}
-              {/each}
-            </div>
-          </div>
-        {:else if block.kind === "assistant-label"}
-          <!-- no label needed -->
-        {:else if block.kind === "thinking"}
-          <div class="assistant-msg">
-            <details class="thinking-block">
-              <summary class="thinking-summary">
-                <span class="thinking-icon">
-                  <Lightbulb size={14} strokeWidth={2} />
-                </span>
-                <span class="thinking-label">Thinking</span>
-                <span class="thinking-chevron"></span>
-              </summary>
-              <div class="thinking-content">
-                <p class="thinking-text">{block.chunk.content}</p>
-              </div>
-            </details>
-          </div>
-        {:else if block.kind === "text"}
-          <div class="assistant-msg">
-            <div class="assistant-card">
-              <div class="assistant-text markdown-body">{@html renderMarkdown(block.chunk.content)}</div>
-            </div>
-          </div>
-        {:else if block.kind === "tool-group"}
-          {@const isExpanded = expandedGroups.has(block.key)}
-          {@const lastTool = block.tools[block.tools.length - 1].chunk}
-          {@const LastIcon = toolIcons[lastTool.name] ?? Settings}
-          {@const isActive = sending && bi === visualBlocks.length - 1}
-          {@const count = block.tools.length}
-          <div class="assistant-msg">
-            <div class="tool-group" class:expanded={isExpanded}>
-              <button class="tool-group-header" onclick={() => toggleGroup(block.key)}>
-                {#if isActive}
-                  <span class="tool-group-spinner"><Loader2 size={13} strokeWidth={2} /></span>
-                {:else}
-                  <span class="tool-group-gear"><Settings size={13} strokeWidth={2} /></span>
-                {/if}
-                <span class="tool-group-latest">
-                  <span class="tool-group-latest-icon"><LastIcon size={12} strokeWidth={2} /></span>
-                  <span class="tool-group-latest-label">{lastTool.input || lastTool.name}</span>
-                </span>
-                {#if count > 1}
-                  <span class="tool-group-count">{count} actions</span>
-                {/if}
-                <span class="tool-group-chevron" class:expanded={isExpanded}>▾</span>
-              </button>
-              {#if isExpanded}
-                <div class="tool-group-body">
-                  {#each block.tools as t}
-                    {@const ToolIcon = toolIcons[t.chunk.name] ?? Settings}
-                    <span class="tool-pill">
-                      <span class="tool-icon"><ToolIcon size={13} strokeWidth={2} /></span>
-                      {t.chunk.input || t.chunk.name}
-                    </span>
-                  {/each}
-                </div>
-              {/if}
-            </div>
-          </div>
-        {:else if block.kind === "special-tool" && block.chunk.name === "AskUserQuestion"}
-          {@const chunk = block.chunk}
-          {@const parsed = (() => { try { return JSON.parse(chunk.input); } catch { return null; } })()}
-          {@const bKey = `${block.msgId}:${block.ci}`}
-          {@const totalQ = parsed && Array.isArray(parsed) ? parsed.length : 0}
-          {@const batchSubmitted = submittedBatches.has(bKey)}
-          {@const bAnswers = batchAnswers.get(bKey)}
-          {@const answeredInBatch = bAnswers?.size ?? 0}
-          <div class="assistant-msg">
-            {#if parsed && Array.isArray(parsed)}
-              {#if batchSubmitted}
-                <!-- Collapsed summary after submission -->
-                <div class="question-card answered">
-                  <div class="question-header">
-                    <span class="question-icon"><MessageCircleQuestion size={15} strokeWidth={2} /></span>
-                    <span class="question-label">{totalQ === 1 ? (parsed[0].header || "Question") : `${totalQ} questions`}</span>
-                    <button
-                      type="button"
-                      class="question-change-btn"
-                      disabled={sending}
-                      onclick={() => unsubmitBatch(bKey)}
-                    >Change</button>
-                  </div>
-                  <div class="question-answers-summary">
-                    {#each parsed as q, qi}
-                      <div class="answer-summary-row">
-                        <span class="answer-summary-label">{q.header || q.question || `Q${qi + 1}`}</span>
-                        <span class="question-answer-pill">{bAnswers?.get(qi)}</span>
+            {:else if block.kind === "user"}
+              <div class="user-msg">
+                {#if block.msg.imageDataUrls && block.msg.imageDataUrls.length > 0}
+                  <div class="user-images">
+                    {#each block.msg.imageDataUrls as dataUrl, di (di)}
+                      <div class="user-image-thumb">
+                        <img src={dataUrl} alt="Attached" />
                       </div>
                     {/each}
                   </div>
+                {/if}
+                {#if block.msg.planMode}
+                  <div class="plan-badge-row">
+                    <span class="plan-badge">
+                      <BookOpen size={11} strokeWidth={2} />
+                      Plan
+                    </span>
+                  </div>
+                {/if}
+                <div class="user-bubble">
+                  {#each block.msg.chunks as chunk, ci (ci)}
+                    {#if chunk.type === "text"}
+                      {#if block.msg.mentions && block.msg.mentions.length > 0}
+                        {#each splitTextWithMentions(chunk.content, block.msg.mentions) as seg, si (si)}
+                          {#if seg.kind === "text"}{seg.value}{:else}
+                            <button
+                              class="msg-mention-chip"
+                              onclick={() => onMentionClick?.(seg.mention.path)}
+                            >@{seg.mention.displayName}</button>
+                          {/if}
+                        {/each}
+                      {:else}
+                        {chunk.content}
+                      {/if}
+                    {/if}
+                  {/each}
                 </div>
-              {:else}
-                <!-- Expanded: individual question cards -->
-                {#each parsed as q, qi}
-                  {@const qKey = `${block.msgId}:${block.ci}:${qi}`}
-                  {@const isMulti = q.multiSelect === true}
-                  {@const answerText = bAnswers?.get(qi)}
-                  {@const hasAnswer = answerText != null}
-                  {@const selected = selectedOptions.get(qKey) ?? new SvelteSet()}
-                  {@const customText = customInputs.get(qKey) ?? ""}
-                  {@const showCustom = showCustomInput.has(qKey)}
+              </div>
+            {:else if block.kind === "assistant-label"}
+              <!-- no label needed -->
+            {:else if block.kind === "thinking"}
+              <div class="assistant-msg">
+                <details class="thinking-block">
+                  <summary class="thinking-summary">
+                    <span class="thinking-icon">
+                      <Lightbulb size={14} strokeWidth={2} />
+                    </span>
+                    <span class="thinking-label">Thinking</span>
+                    <span class="thinking-chevron"></span>
+                  </summary>
+                  <div class="thinking-content">
+                    <p class="thinking-text">{block.chunk.content}</p>
+                  </div>
+                </details>
+              </div>
+            {:else if block.kind === "text"}
+              <div class="assistant-msg">
+                <div class="assistant-card">
+                  <div class="assistant-text markdown-body">{@html renderMarkdown(block.chunk.content)}</div>
+                </div>
+              </div>
+            {:else if block.kind === "tool-group"}
+              {@const isExpanded = expandedGroups.has(block.key)}
+              {@const lastTool = block.tools[block.tools.length - 1].chunk}
+              {@const LastIcon = toolIcons[lastTool.name] ?? Settings}
+              {@const isActive = sending && bi === visualBlocks.length - 1}
+              {@const toolCount = block.tools.length}
+              <div class="assistant-msg">
+                <div class="tool-group" class:expanded={isExpanded}>
+                  <button class="tool-group-header" onclick={() => toggleGroup(block.key)}>
+                    {#if isActive}
+                      <span class="tool-group-spinner"><Loader2 size={13} strokeWidth={2} /></span>
+                    {:else}
+                      <span class="tool-group-gear"><Settings size={13} strokeWidth={2} /></span>
+                    {/if}
+                    <span class="tool-group-latest">
+                      <span class="tool-group-latest-icon"><LastIcon size={12} strokeWidth={2} /></span>
+                      <span class="tool-group-latest-label">{lastTool.input || lastTool.name}</span>
+                    </span>
+                    {#if toolCount > 1}
+                      <span class="tool-group-count">{toolCount} actions</span>
+                    {/if}
+                    <span class="tool-group-chevron" class:expanded={isExpanded}>▾</span>
+                  </button>
+                  {#if isExpanded}
+                    <div class="tool-group-body">
+                      {#each block.tools as t (`${t.msgId}:${t.ci}`)}
+                        {@const ToolIcon = toolIcons[t.chunk.name] ?? Settings}
+                        <span class="tool-pill">
+                          <span class="tool-icon"><ToolIcon size={13} strokeWidth={2} /></span>
+                          {t.chunk.input || t.chunk.name}
+                        </span>
+                      {/each}
+                    </div>
+                  {/if}
+                </div>
+              </div>
+            {:else if block.kind === "special-tool" && block.chunk.name === "AskUserQuestion"}
+              {@const chunk = block.chunk}
+              {@const parsed = (() => { try { return JSON.parse(chunk.input); } catch { return null; } })()}
+              {@const bKey = `${block.msgId}:${block.ci}`}
+              {@const totalQ = parsed && Array.isArray(parsed) ? parsed.length : 0}
+              {@const batchSubmitted = submittedBatches.has(bKey)}
+              {@const bAnswers = batchAnswers.get(bKey)}
+              {@const answeredInBatch = bAnswers?.size ?? 0}
+              <div class="assistant-msg">
+                {#if parsed && Array.isArray(parsed)}
+                  {#if batchSubmitted}
+                    <div class="question-card answered">
+                      <div class="question-header">
+                        <span class="question-icon"><MessageCircleQuestion size={15} strokeWidth={2} /></span>
+                        <span class="question-label">{totalQ === 1 ? (parsed[0].header || "Question") : `${totalQ} questions`}</span>
+                        <button
+                          type="button"
+                          class="question-change-btn"
+                          disabled={sending}
+                          onclick={() => unsubmitBatch(bKey)}
+                        >Change</button>
+                      </div>
+                      <div class="question-answers-summary">
+                        {#each parsed as q, qi (qi)}
+                          <div class="answer-summary-row">
+                            <span class="answer-summary-label">{q.header || q.question || `Q${qi + 1}`}</span>
+                            <span class="question-answer-pill">{bAnswers?.get(qi)}</span>
+                          </div>
+                        {/each}
+                      </div>
+                    </div>
+                  {:else}
+                    {#each parsed as q, qi (qi)}
+                      {@const qKey = `${block.msgId}:${block.ci}:${qi}`}
+                      {@const isMulti = q.multiSelect === true}
+                      {@const answerText = bAnswers?.get(qi)}
+                      {@const hasAnswer = answerText != null}
+                      {@const selected = selectedOptions.get(qKey) ?? new SvelteSet()}
+                      {@const customText = customInputs.get(qKey) ?? ""}
+                      {@const showCustom = showCustomInput.has(qKey)}
+                      <div class="question-card">
+                        <div class="question-header">
+                          <span class="question-icon"><MessageCircleQuestion size={15} strokeWidth={2} /></span>
+                          <span class="question-label">{q.header || "Question"}</span>
+                          {#if isMulti}
+                            <span class="question-multi-badge">Multi-select</span>
+                          {/if}
+                          {#if hasAnswer}
+                            <span class="question-answer-pill">{answerText}</span>
+                          {/if}
+                        </div>
+                        {#if q.question}
+                          <div class="question-text">{q.question}</div>
+                        {/if}
+                        {#if q.options && q.options.length > 0}
+                          <div class="question-options">
+                            {#each q.options as opt (opt.label)}
+                              {#if isMulti}
+                                <button
+                                  type="button"
+                                  class="question-option"
+                                  class:selected={selected.has(opt.label)}
+                                  disabled={sending}
+                                  onclick={() => toggleOption(qKey, opt.label)}
+                                >
+                                  <span class="option-check">{selected.has(opt.label) ? "◉" : "○"}</span>
+                                  <span class="option-content">
+                                    <span class="option-label">{opt.label}</span>
+                                    {#if opt.description}
+                                      <span class="option-desc">{opt.description}</span>
+                                    {/if}
+                                  </span>
+                                </button>
+                              {:else}
+                                <button
+                                  type="button"
+                                  class="question-option"
+                                  class:selected-answer={hasAnswer && answerText === opt.label}
+                                  disabled={sending}
+                                  onclick={() => submitOption(qKey, opt.label, totalQ)}
+                                >
+                                  <span class="option-content">
+                                    <span class="option-label">{opt.label}</span>
+                                    {#if opt.description}
+                                      <span class="option-desc">{opt.description}</span>
+                                    {/if}
+                                  </span>
+                                </button>
+                              {/if}
+                            {/each}
+                            {#if showCustom}
+                              <div class="custom-input-row">
+                                <input
+                                  type="text"
+                                  class="custom-input"
+                                  placeholder="Type your answer…"
+                                  value={customText}
+                                  disabled={sending}
+                                  oninput={(e) => customInputs.set(qKey, (e.target as HTMLInputElement).value)}
+                                  onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); isMulti ? submitMultiSelect(qKey, totalQ) : submitCustomInput(qKey, totalQ); } }}
+                                />
+                                <button
+                                  type="button"
+                                  class="custom-submit-btn"
+                                  disabled={sending || (!customText.trim() && (!isMulti || selected.size === 0))}
+                                  onclick={() => isMulti ? submitMultiSelect(qKey, totalQ) : submitCustomInput(qKey, totalQ)}
+                                >
+                                  <ArrowUp size={14} strokeWidth={2.5} />
+                                </button>
+                              </div>
+                            {:else}
+                              <button
+                                type="button"
+                                class="question-option other-option"
+                                disabled={sending}
+                                onclick={() => showCustomInput.add(qKey)}
+                              >
+                                <span class="option-content">
+                                  <span class="option-label">Other</span>
+                                  <span class="option-desc">Type a custom answer</span>
+                                </span>
+                              </button>
+                            {/if}
+                            {#if isMulti && selected.size > 0}
+                              <button
+                                type="button"
+                                class="multi-submit-btn"
+                                disabled={sending}
+                                onclick={() => submitMultiSelect(qKey, totalQ)}
+                              >
+                                Submit ({selected.size} selected)
+                              </button>
+                            {/if}
+                          </div>
+                        {/if}
+                      </div>
+                    {/each}
+                    {#if totalQ > 1 && answeredInBatch >= totalQ}
+                      <button
+                        type="button"
+                        class="batch-submit-btn"
+                        disabled={sending}
+                        onclick={() => submitBatch(bKey, totalQ)}
+                      >
+                        <ArrowUp size={14} strokeWidth={2.5} />
+                        Submit all {totalQ} answers
+                      </button>
+                    {:else if totalQ > 1 && answeredInBatch > 0}
+                      <div class="batch-progress">
+                        {answeredInBatch} of {totalQ} questions answered
+                      </div>
+                    {/if}
+                  {/if}
+                {:else}
                   <div class="question-card">
                     <div class="question-header">
                       <span class="question-icon"><MessageCircleQuestion size={15} strokeWidth={2} /></span>
-                      <span class="question-label">{q.header || "Question"}</span>
-                      {#if isMulti}
-                        <span class="question-multi-badge">Multi-select</span>
-                      {/if}
-                      {#if hasAnswer}
-                        <span class="question-answer-pill">{answerText}</span>
-                      {/if}
+                      <span class="question-label">Question</span>
                     </div>
-                    {#if q.question}
-                      <div class="question-text">{q.question}</div>
-                    {/if}
-                    {#if q.options && q.options.length > 0}
-                      <div class="question-options">
-                        {#each q.options as opt}
-                          {#if isMulti}
-                            <button
-                              type="button"
-                              class="question-option"
-                              class:selected={selected.has(opt.label)}
-                              disabled={sending}
-                              onclick={() => toggleOption(qKey, opt.label)}
-                            >
-                              <span class="option-check">{selected.has(opt.label) ? "◉" : "○"}</span>
-                              <span class="option-content">
-                                <span class="option-label">{opt.label}</span>
-                                {#if opt.description}
-                                  <span class="option-desc">{opt.description}</span>
-                                {/if}
-                              </span>
-                            </button>
-                          {:else}
-                            <button
-                              type="button"
-                              class="question-option"
-                              class:selected-answer={hasAnswer && answerText === opt.label}
-                              disabled={sending}
-                              onclick={() => submitOption(qKey, opt.label, totalQ)}
-                            >
-                              <span class="option-content">
-                                <span class="option-label">{opt.label}</span>
-                                {#if opt.description}
-                                  <span class="option-desc">{opt.description}</span>
-                                {/if}
-                              </span>
-                            </button>
-                          {/if}
-                        {/each}
-                        {#if showCustom}
-                          <div class="custom-input-row">
-                            <input
-                              type="text"
-                              class="custom-input"
-                              placeholder="Type your answer…"
-                              value={customText}
-                              disabled={sending}
-                              oninput={(e) => customInputs.set(qKey, (e.target as HTMLInputElement).value)}
-                              onkeydown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); isMulti ? submitMultiSelect(qKey, totalQ) : submitCustomInput(qKey, totalQ); } }}
-                            />
-                            <button
-                              type="button"
-                              class="custom-submit-btn"
-                              disabled={sending || (!customText.trim() && (!isMulti || selected.size === 0))}
-                              onclick={() => isMulti ? submitMultiSelect(qKey, totalQ) : submitCustomInput(qKey, totalQ)}
-                            >
-                              <ArrowUp size={14} strokeWidth={2.5} />
-                            </button>
-                          </div>
-                        {:else}
-                          <button
-                            type="button"
-                            class="question-option other-option"
-                            disabled={sending}
-                            onclick={() => showCustomInput.add(qKey)}
-                          >
-                            <span class="option-content">
-                              <span class="option-label">Other</span>
-                              <span class="option-desc">Type a custom answer</span>
-                            </span>
-                          </button>
-                        {/if}
-                        {#if isMulti && selected.size > 0}
-                          <button
-                            type="button"
-                            class="multi-submit-btn"
-                            disabled={sending}
-                            onclick={() => submitMultiSelect(qKey, totalQ)}
-                          >
-                            Submit ({selected.size} selected)
-                          </button>
-                        {/if}
-                      </div>
-                    {/if}
-                  </div>
-                {/each}
-                {#if totalQ > 1 && answeredInBatch >= totalQ}
-                  <button
-                    type="button"
-                    class="batch-submit-btn"
-                    disabled={sending}
-                    onclick={() => submitBatch(bKey, totalQ)}
-                  >
-                    <ArrowUp size={14} strokeWidth={2.5} />
-                    Submit all {totalQ} answers
-                  </button>
-                {:else if totalQ > 1 && answeredInBatch > 0}
-                  <div class="batch-progress">
-                    {answeredInBatch} of {totalQ} questions answered
+                    <div class="question-text">{chunk.input}</div>
                   </div>
                 {/if}
-              {/if}
-            {:else}
-              <div class="question-card">
-                <div class="question-header">
-                  <span class="question-icon"><MessageCircleQuestion size={15} strokeWidth={2} /></span>
-                  <span class="question-label">Question</span>
+              </div>
+            {:else if block.kind === "special-tool" && block.chunk.oldString != null && block.chunk.newString != null}
+              {@const chunk = block.chunk}
+              {@const diffKey = `${block.msgId}:${block.ci}`}
+              {@const isCollapsed = collapsedDiffs.has(diffKey)}
+              <div class="assistant-msg">
+                <div class="edit-diff-block">
+                  <button class="edit-diff-header" onclick={() => {
+                    if (collapsedDiffs.has(diffKey)) {
+                      collapsedDiffs.delete(diffKey);
+                    } else {
+                      collapsedDiffs.add(diffKey);
+                    }
+                  }}>
+                    <span class="edit-diff-chevron" class:collapsed={isCollapsed}>▾</span>
+                    <span class="edit-diff-icon"><Pencil size={13} strokeWidth={2} /></span>
+                    <span class="edit-diff-label">{chunk.input}</span>
+                  </button>
+                  {#if !isCollapsed}
+                    <div class="edit-diff-body">
+                      {#each (chunk.oldString ?? "").split("\n") as line, li (li)}
+                        <div class="diff-line remove"><span class="diff-ln">{li + 1}</span><span class="diff-prefix">-</span><span class="diff-code">{line}</span></div>
+                      {/each}
+                      {#each (chunk.newString ?? "").split("\n") as line, li (li)}
+                        <div class="diff-line add"><span class="diff-ln">{li + 1}</span><span class="diff-prefix">+</span><span class="diff-code">{line}</span></div>
+                      {/each}
+                    </div>
+                  {/if}
                 </div>
-                <div class="question-text">{chunk.input}</div>
               </div>
             {/if}
           </div>
-        {:else if block.kind === "special-tool" && block.chunk.oldString != null && block.chunk.newString != null}
-          {@const chunk = block.chunk}
-          {@const diffKey = `${block.msgId}:${block.ci}`}
-          {@const isCollapsed = collapsedDiffs.has(diffKey)}
-          <div class="assistant-msg">
-            <div class="edit-diff-block">
-              <button class="edit-diff-header" onclick={() => {
-                if (collapsedDiffs.has(diffKey)) {
-                  collapsedDiffs.delete(diffKey);
-                } else {
-                  collapsedDiffs.add(diffKey);
-                }
-              }}>
-                <span class="edit-diff-chevron" class:collapsed={isCollapsed}>▾</span>
-                <span class="edit-diff-icon"><Pencil size={13} strokeWidth={2} /></span>
-                <span class="edit-diff-label">{chunk.input}</span>
-              </button>
-              {#if !isCollapsed}
-                <div class="edit-diff-body">
-                  {#each (chunk.oldString ?? "").split("\n") as line, li}
-                    <div class="diff-line remove"><span class="diff-ln">{li + 1}</span><span class="diff-prefix">-</span><span class="diff-code">{line}</span></div>
-                  {/each}
-                  {#each (chunk.newString ?? "").split("\n") as line, li}
-                    <div class="diff-line add"><span class="diff-ln">{li + 1}</span><span class="diff-prefix">+</span><span class="diff-code">{line}</span></div>
-                  {/each}
+        {:else}
+          <!-- Footer: file pills + plan actions + thinking indicator -->
+          <div class="virtual-block virtual-footer">
+            {#if recentFiles.length > 0 && !sending}
+              <div class="file-pills-row">
+                {#each recentFiles as file (file)}
+                  <span class="file-pill">
+                    <span class="file-pill-icon">∞</span>
+                    {file}
+                  </span>
+                {/each}
+              </div>
+            {/if}
+            {#if showExecutePlan}
+              <div class="plan-actions-row">
+                <button
+                  type="button"
+                  class="plan-action-btn execute"
+                  onclick={() => onExecutePlan?.()}
+                >
+                  <Play size={14} strokeWidth={2} />
+                  Execute plan
+                </button>
+                <button
+                  type="button"
+                  class="plan-action-btn revise"
+                  onclick={() => { planActionsHiddenAt = messages.length; mentionInputApi?.focus(); }}
+                >
+                  <Pencil size={14} strokeWidth={2} />
+                  Revise
+                </button>
+              </div>
+            {/if}
+            {#if sending}
+              <div class="assistant-msg">
+                <div class="thinking">
+                  <Timer size={13} strokeWidth={2} />
+                  <span class="thinking-timer">{thinkingElapsed}s</span>
                 </div>
-              {/if}
-            </div>
+              </div>
+            {/if}
           </div>
         {/if}
-      {/each}
-
-      <!-- File pills after last assistant turn -->
-      {#if recentFiles.length > 0 && !sending}
-        <div class="file-pills-row">
-          {#each recentFiles as file}
-            <span class="file-pill">
-              <span class="file-pill-icon">∞</span>
-              {file}
-            </span>
-          {/each}
-        </div>
-      {/if}
-
-      <!-- Plan approval buttons after a plan-mode response -->
-      {#if showExecutePlan}
-        <div class="plan-actions-row">
-          <button
-            type="button"
-            class="plan-action-btn execute"
-            onclick={() => onExecutePlan?.()}
-          >
-            <Play size={14} strokeWidth={2} />
-            Execute plan
-          </button>
-          <button
-            type="button"
-            class="plan-action-btn revise"
-            onclick={() => { planActionsHiddenAt = messages.length; mentionInputApi?.focus(); }}
-          >
-            <Pencil size={14} strokeWidth={2} />
-            Revise
-          </button>
-        </div>
-      {/if}
-
-      {#if sending}
-        <div class="assistant-msg">
-          <div class="thinking">
-            <Timer size={13} strokeWidth={2} />
-            <span class="thinking-timer">{thinkingElapsed}s</span>
-          </div>
-        </div>
-      {/if}
-    {/if}
-  </div>
+      {/snippet}
+    </VirtualScroller>
+  {/if}
 
   {#if queue.length > 0}
     <div class="queue-strip">
@@ -957,10 +965,20 @@
     min-height: 0;
   }
 
-  .chat-area {
+  .chat-area-static {
     flex: 1;
     overflow-y: auto;
     padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .virtual-block {
+    padding: 0 1.25rem;
+  }
+
+  .virtual-footer {
     display: flex;
     flex-direction: column;
     gap: 0.6rem;

--- a/src/lib/components/VirtualScroller.svelte
+++ b/src/lib/components/VirtualScroller.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+  import { untrack } from "svelte";
+
+  interface Props {
+    /** Total number of items */
+    count: number;
+    /** Estimated height for items not yet measured (px) */
+    estimatedHeight?: number;
+    /** Gap between items in px */
+    gap?: number;
+    /** Extra items to render above/below the visible window */
+    overscan?: number;
+    /** Snippet that renders each item by index */
+    children: import("svelte").Snippet<[number]>;
+    /** If true, keep scroll pinned to bottom when new items arrive */
+    stickToBottom?: boolean;
+    /** Called when user scrolls away from bottom */
+    onscrolledUp?: (scrolledUp: boolean) => void;
+  }
+
+  let {
+    count,
+    estimatedHeight = 60,
+    gap = 0,
+    overscan = 5,
+    children,
+    stickToBottom = false,
+    onscrolledUp,
+  }: Props = $props();
+
+  let container: HTMLDivElement | undefined = $state();
+  let viewportHeight = $state(0);
+  let scrollTop = $state(0);
+
+  // Measured heights per index. Plain Map — not reactive, we batch updates.
+  const measuredHeights = new Map<number, number>();
+  // Track which indices have active ResizeObservers
+  const observedElements = new Map<number, Element>();
+
+  let resizeObserver: ResizeObserver | undefined;
+
+  // Trigger re-render when measurements change
+  let measureVersion = $state(0);
+
+  function getHeight(index: number): number {
+    return measuredHeights.get(index) ?? estimatedHeight;
+  }
+
+  // Compute cumulative offsets and total height
+  function getLayout(_version: number) {
+    const offsets: number[] = new Array(count);
+    let y = 0;
+    for (let i = 0; i < count; i++) {
+      offsets[i] = y;
+      y += getHeight(i) + gap;
+    }
+    const totalHeight = count > 0 ? y - gap : 0;
+    return { offsets, totalHeight };
+  }
+
+  let layout = $derived(getLayout(measureVersion));
+
+  // Find first visible index via binary search
+  function findStartIndex(top: number, offsets: number[]): number {
+    let lo = 0;
+    let hi = offsets.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      if (offsets[mid] <= top) {
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return Math.max(0, hi);
+  }
+
+  let visibleRange = $derived.by(() => {
+    if (count === 0) return { start: 0, end: 0 };
+    const { offsets } = layout;
+    const startRaw = findStartIndex(scrollTop, offsets);
+    const start = Math.max(0, startRaw - overscan);
+
+    const endY = scrollTop + viewportHeight;
+    let end = startRaw;
+    while (end < count && offsets[end] < endY) {
+      end++;
+    }
+    end = Math.min(count, end + overscan);
+
+    return { start, end };
+  });
+
+  // ── Scroll position management ──────────────────────────────────
+
+  let wasAtBottom = true;
+
+  function handleScroll() {
+    if (!container) return;
+    scrollTop = container.scrollTop;
+    const atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 50;
+    wasAtBottom = atBottom;
+    onscrolledUp?.(!atBottom);
+  }
+
+  // Scroll to bottom ONLY when new items are added (count increases).
+  // NOT on measureVersion changes — those should preserve scroll position.
+  let prevCountForScroll = 0;
+  $effect(() => {
+    const c = count;
+    if (c > prevCountForScroll && wasAtBottom && stickToBottom && container) {
+      untrack(() => {
+        requestAnimationFrame(() => {
+          if (container) {
+            container.scrollTop = container.scrollHeight;
+            scrollTop = container.scrollTop;
+          }
+        });
+      });
+    }
+    prevCountForScroll = c;
+  });
+
+  // ── Scroll anchoring on measurement changes ─────────────────────
+  // When ResizeObserver updates heights, items above the viewport may shift.
+  // Adjust scrollTop so the first visible item stays in place.
+
+  let anchorIndex = $state(-1);
+  let anchorOffset = $state(0);
+
+  // Before layout recalculation, capture what the user is looking at.
+  $effect.pre(() => {
+    // Read measureVersion to run before layout recomputes
+    const _v = measureVersion;
+    if (!container || count === 0) return;
+    const { offsets } = untrack(() => layout);
+    const idx = findStartIndex(container.scrollTop, offsets);
+    anchorIndex = idx;
+    anchorOffset = container.scrollTop - (offsets[idx] ?? 0);
+  });
+
+  // After layout recalculation, restore the anchor position.
+  $effect(() => {
+    const _v = measureVersion;
+    if (!container || anchorIndex < 0 || wasAtBottom) return;
+    const { offsets } = layout;
+    const newTop = (offsets[anchorIndex] ?? 0) + anchorOffset;
+    if (Math.abs(container.scrollTop - newTop) > 1) {
+      container.scrollTop = newTop;
+      scrollTop = newTop;
+    }
+  });
+
+  // ── ResizeObserver setup ────────────────────────────────────────
+
+  $effect(() => {
+    resizeObserver = new ResizeObserver((entries) => {
+      let changed = false;
+      for (const entry of entries) {
+        const el = entry.target as HTMLElement;
+        const idx = parseInt(el.dataset.vindex!, 10);
+        if (isNaN(idx)) continue;
+        const h = entry.borderBoxSize?.[0]?.blockSize ?? el.getBoundingClientRect().height;
+        const prev = measuredHeights.get(idx);
+        if (prev !== h) {
+          measuredHeights.set(idx, h);
+          changed = true;
+        }
+      }
+      if (changed) {
+        measureVersion++;
+      }
+    });
+
+    return () => {
+      resizeObserver?.disconnect();
+      resizeObserver = undefined;
+      observedElements.clear();
+    };
+  });
+
+  // Svelte action: observe element height via ResizeObserver
+  function observeItem(el: HTMLElement, index: number) {
+    let currentIndex = index;
+
+    function startObserving() {
+      if (!resizeObserver) return;
+      const prev = observedElements.get(currentIndex);
+      if (prev && prev !== el) resizeObserver.unobserve(prev);
+      observedElements.set(currentIndex, el);
+      el.dataset.vindex = String(currentIndex);
+      resizeObserver.observe(el);
+    }
+
+    startObserving();
+
+    return {
+      update(newIndex: number) {
+        if (newIndex !== currentIndex) {
+          if (observedElements.get(currentIndex) === el) {
+            resizeObserver?.unobserve(el);
+            observedElements.delete(currentIndex);
+          }
+          currentIndex = newIndex;
+          startObserving();
+        }
+      },
+      destroy() {
+        if (observedElements.get(currentIndex) === el) {
+          resizeObserver?.unobserve(el);
+          observedElements.delete(currentIndex);
+        }
+      },
+    };
+  }
+
+  // Measure viewport height
+  $effect(() => {
+    if (!container) return;
+    const ro = new ResizeObserver(([entry]) => {
+      viewportHeight = entry.contentRect.height;
+    });
+    ro.observe(container);
+    viewportHeight = container.clientHeight;
+    return () => ro.disconnect();
+  });
+
+  // Only clear measured heights for indices that no longer exist.
+  // Avoids nuking all cached heights when footer toggles (count changes by 1).
+  let prevCount = 0;
+  $effect.pre(() => {
+    if (count < prevCount) {
+      for (let i = count; i < prevCount; i++) {
+        measuredHeights.delete(i);
+      }
+    }
+    prevCount = count;
+  });
+</script>
+
+<div
+  class="virtual-scroller"
+  bind:this={container}
+  onscroll={handleScroll}
+>
+  <div class="virtual-content" style="height: {layout.totalHeight}px; position: relative;">
+    {#each { length: visibleRange.end - visibleRange.start } as _, i}
+      {@const index = visibleRange.start + i}
+      {@const top = layout.offsets[index]}
+      <div
+        class="virtual-item"
+        style="position: absolute; top: {top}px; left: 0; right: 0;"
+        use:observeItem={index}
+      >
+        {@render children(index)}
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .virtual-scroller {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+</style>

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -80,11 +80,20 @@ marked.setOptions({
   breaks: false,
 });
 
+// Cache rendered HTML keyed by raw markdown string.
+// Messages are immutable once added, so cache entries never go stale.
+const renderCache = new Map<string, string>();
+
 /**
  * Render a markdown string to sanitized HTML.
  * Synchronous — safe to call inline in Svelte templates.
+ * Results are cached so re-renders skip parsing/highlighting entirely.
  */
 export function renderMarkdown(raw: string): string {
+  const cached = renderCache.get(raw);
+  if (cached !== undefined) return cached;
   const html = marked.parse(raw) as string;
-  return DOMPurify.sanitize(html);
+  const sanitized = DOMPurify.sanitize(html);
+  renderCache.set(raw, sanitized);
+  return sanitized;
 }

--- a/src/lib/stores/messages.svelte.ts
+++ b/src/lib/stores/messages.svelte.ts
@@ -19,17 +19,17 @@ export interface Message {
   role: "user" | "assistant" | "action";
   chunks: MessageChunk[];
   done: boolean;
-  actionLabel?: string; // compact label for action messages (e.g. "Creating PR", "Merging")
-  imageDataUrls?: string[]; // data URLs for attached image thumbnails (user messages only)
-  mentions?: MessageMention[]; // @-mentioned files/folders (user messages only)
-  planMode?: boolean; // true if this message was sent in plan mode
+  actionLabel?: string;
+  imageDataUrls?: string[];
+  mentions?: MessageMention[];
+  planMode?: boolean;
 }
 
 // ── State ──────────────────────────────────────────────────────────
-// Keyed by workspaceId → Message[]
-// Each mutation replaces the array reference so Svelte's Map proxy sees a real change.
+// Keyed by workspaceId → Map<messageId, Message>
+// Updating one message = one reactive cell, not the whole list.
 
-export const messagesByWorkspace = new SvelteMap<string, Message[]>();
+export const messagesByWorkspace = new SvelteMap<string, SvelteMap<string, Message>>();
 export const sendingByWorkspace = new SvelteMap<string, boolean>();
 
 export function setSending(wsId: string, value: boolean) {
@@ -40,27 +40,21 @@ export function isSending(wsId: string): boolean {
   return sendingByWorkspace.get(wsId) ?? false;
 }
 
-// Internal lookup maps for O(1) dedup/update (plain JS, not reactive).
-const _lookups = new Map<string, Map<string, number>>();
-
 // ── Helpers ────────────────────────────────────────────────────────
 
-function ensureLookup(workspaceId: string): Map<string, number> {
-  let lookup = _lookups.get(workspaceId);
-  if (!lookup) {
-    lookup = new Map();
-    _lookups.set(workspaceId, lookup);
+function ensureMap(workspaceId: string): SvelteMap<string, Message> {
+  let map = messagesByWorkspace.get(workspaceId);
+  if (!map) {
+    map = new SvelteMap();
+    messagesByWorkspace.set(workspaceId, map);
   }
-  return lookup;
+  return map;
 }
 
-/** Push a message and replace the array reference so the $state proxy signals a change. */
+/** Add a message to the workspace's map. */
 function pushMessage(workspaceId: string, msg: Message) {
-  const arr = messagesByWorkspace.get(workspaceId) ?? [];
-  const lookup = ensureLookup(workspaceId);
-  const newArr = [...arr, msg];
-  lookup.set(msg.id, newArr.length - 1);
-  messagesByWorkspace.set(workspaceId, newArr);
+  const map = ensureMap(workspaceId);
+  map.set(msg.id, msg);
 }
 
 /** Add a complete user message */
@@ -127,11 +121,10 @@ export function addAssistantMessage(
   persistMessages(workspaceId);
 }
 
-const EMPTY_MESSAGES: Message[] = [];
-
-/** Get messages for a workspace — reads directly from the $state Map. */
+/** Get messages for a workspace as an ordered array. */
 export function getMessages(workspaceId: string): Message[] {
-  return messagesByWorkspace.get(workspaceId) ?? EMPTY_MESSAGES;
+  const map = messagesByWorkspace.get(workspaceId);
+  return map ? [...map.values()] : [];
 }
 
 /** Load persisted messages from disk */
@@ -141,12 +134,11 @@ export async function loadPersistedMessages(
   try {
     const raw = (await loadMessages(workspaceId)) as Message[];
     if (raw.length === 0) return;
-    const lookup = ensureLookup(workspaceId);
+    const map = ensureMap(workspaceId);
     for (const msg of raw) {
-      lookup.set(msg.id, lookup.size);
+      map.set(msg.id, msg);
     }
-    messagesByWorkspace.set(workspaceId, raw);
-    } catch {
+  } catch {
     // No saved messages
   }
 }
@@ -162,9 +154,9 @@ function persistMessages(workspaceId: string) {
     workspaceId,
     setTimeout(() => {
       pendingSaves.delete(workspaceId);
-      const msgs = messagesByWorkspace.get(workspaceId);
-      if (!msgs) return;
-      saveMessages(workspaceId, msgs).catch(() => {});
+      const map = messagesByWorkspace.get(workspaceId);
+      if (!map) return;
+      saveMessages(workspaceId, [...map.values()]).catch(() => {});
     }, 500),
   );
 }
@@ -176,9 +168,9 @@ export function flushPersist(workspaceId: string) {
     clearTimeout(existing);
     pendingSaves.delete(workspaceId);
   }
-  const msgs = messagesByWorkspace.get(workspaceId);
-  if (!msgs) return;
-  saveMessages(workspaceId, msgs).catch(() => {});
+  const map = messagesByWorkspace.get(workspaceId);
+  if (!map) return;
+  saveMessages(workspaceId, [...map.values()]).catch(() => {});
 }
 
 /** Remove all in-memory state for a workspace (call on remove) */
@@ -187,5 +179,4 @@ export function clearWorkspaceData(workspaceId: string) {
   if (pending) clearTimeout(pending);
   pendingSaves.delete(workspaceId);
   messagesByWorkspace.delete(workspaceId);
-  _lookups.delete(workspaceId);
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1202,81 +1202,85 @@ No need to mention in your report whether or not you used one of the fallback st
       />
     {/if}
 
-    {#if appMode === "work"}
-      <div class="main-layout">
-        <Sidebar
-          {workspaces}
-          {selectedWsId}
-          {creatingWsId}
-          {prStatusMap}
-          {reviewingWsIds}
-          onSelect={selectWorkspace}
-          onNewWorkspace={handleNewWorkspace}
-          onRename={handleRename}
-          onRemove={handleRemove}
-        />
+    <div class="mode-stack">
+      <div class="mode-layer" class:mode-visible={appMode === "work"} inert={appMode !== "work"}>
+        <div class="main-layout">
+          <Sidebar
+            {workspaces}
+            {selectedWsId}
+            {creatingWsId}
+            {prStatusMap}
+            {reviewingWsIds}
+            onSelect={selectWorkspace}
+            onNewWorkspace={handleNewWorkspace}
+            onRename={handleRename}
+            onRemove={handleRemove}
+          />
 
-        <WorkspacePanel
-          bind:activeTab
-          bind:fileNavigatePath
-          {selectedWs}
-          {selectedWsId}
-          {activeWorkspaces}
-          {creatingWsId}
+          <WorkspacePanel
+            bind:activeTab
+            bind:fileNavigatePath
+            {selectedWs}
+            {selectedWsId}
+            {activeWorkspaces}
+            {creatingWsId}
+            {changeCounts}
+            {planModeByWorkspace}
+            {thinkingModeByWorkspace}
+            {reviewByWorkspace}
+            {repoSettings}
+            {diffRefreshTrigger}
+            getQueueItems={(wsId) => (queueByWorkspace.get(wsId) ?? []).map(q => ({
+              id: q.id,
+              prompt: q.prompt,
+              imageCount: q.images.length,
+              mentionCount: q.mentions.length,
+              planMode: q.planMode,
+            }))}
+            onSend={(prompt, images, mentions, planMode) => handleSend(prompt, images, mentions, planMode)}
+            onSendImmediate={(prompt) => handleSendImmediate(prompt)}
+            onStop={handleStop}
+            onRemoveFromQueue={(wsId, id) => removeFromQueue(wsId, id)}
+            onPlanModeChange={(wsId, enabled) => planModeByWorkspace.set(wsId, enabled)}
+            onThinkingModeChange={(wsId, enabled) => thinkingModeByWorkspace.set(wsId, enabled)}
+            onExecutePlan={(wsId) => {
+              planModeByWorkspace.set(wsId, false);
+              sendPrompt(wsId, "Execute the plan above. Do not ask for confirmation — just do it.", "Executing plan");
+            }}
+            onChatReady={(wsId, api) => chatPanelApis.set(wsId, api)}
+            onReviewCancel={(wsId) => {
+              const wasRunning = reviewByWorkspace.get(wsId)?.status === "running";
+              reviewByWorkspace.delete(wsId);
+              if (wasRunning) stopAgent(wsId).catch((e) => { addToast(String(e)); });
+            }}
+            onReviewSendToChat={(wsId, markdown) => {
+              reviewByWorkspace.delete(wsId);
+              sendPrompt(wsId, `Address all issues from this code review:\n\n${markdown}`, "Addressing review").catch((e) => { addToast(String(e)); });
+            }}
+          />
+        </div>
+      </div>
+
+      <div class="mode-layer" class:mode-visible={appMode === "plan"} inert={appMode !== "plan"}>
+        <KanbanBoard
+          todos={todoItems}
+          inProgress={inProgressWs}
+          review={reviewWs}
+          done={doneWs}
+          {prStatusMap}
           {changeCounts}
-          {planModeByWorkspace}
-          {thinkingModeByWorkspace}
-          {reviewByWorkspace}
-          {repoSettings}
-          {diffRefreshTrigger}
-          getQueueItems={(wsId) => (queueByWorkspace.get(wsId) ?? []).map(q => ({
-            id: q.id,
-            prompt: q.prompt,
-            imageCount: q.images.length,
-            mentionCount: q.mentions.length,
-            planMode: q.planMode,
-          }))}
-          onSend={(prompt, images, mentions, planMode) => handleSend(prompt, images, mentions, planMode)}
-          onSendImmediate={(prompt) => handleSendImmediate(prompt)}
-          onStop={handleStop}
-          onRemoveFromQueue={(wsId, id) => removeFromQueue(wsId, id)}
-          onPlanModeChange={(wsId, enabled) => planModeByWorkspace.set(wsId, enabled)}
-          onThinkingModeChange={(wsId, enabled) => thinkingModeByWorkspace.set(wsId, enabled)}
-          onExecutePlan={(wsId) => {
-            planModeByWorkspace.set(wsId, false);
-            sendPrompt(wsId, "Execute the plan above. Do not ask for confirmation — just do it.", "Executing plan");
-          }}
-          onChatReady={(wsId, api) => chatPanelApis.set(wsId, api)}
-          onReviewCancel={(wsId) => {
-            const wasRunning = reviewByWorkspace.get(wsId)?.status === "running";
-            reviewByWorkspace.delete(wsId);
-            if (wasRunning) stopAgent(wsId).catch((e) => { addToast(String(e)); });
-          }}
-          onReviewSendToChat={(wsId, markdown) => {
-            reviewByWorkspace.delete(wsId);
-            sendPrompt(wsId, `Address all issues from this code review:\n\n${markdown}`, "Addressing review").catch((e) => { addToast(String(e)); });
-          }}
+          {reviewingWsIds}
+          {creatingWsId}
+          repoName={activeRepo.display_name}
+          onCardClick={handleKanbanCardClick}
+          onSpawnAgent={handleSpawnFromTodo}
+          onNewTodo={handleNewTodo}
+          onEditTodo={handleEditTodo}
+          onRemoveTodo={handleRemoveTodo}
+          onRemoveWorkspace={handleRemove}
         />
       </div>
-    {:else}
-      <KanbanBoard
-        todos={todoItems}
-        inProgress={inProgressWs}
-        review={reviewWs}
-        done={doneWs}
-        {prStatusMap}
-        {changeCounts}
-        {reviewingWsIds}
-        {creatingWsId}
-        repoName={activeRepo.display_name}
-        onCardClick={handleKanbanCardClick}
-        onSpawnAgent={handleSpawnFromTodo}
-        onNewTodo={handleNewTodo}
-        onEditTodo={handleEditTodo}
-        onRemoveTodo={handleRemoveTodo}
-        onRemoveWorkspace={handleRemove}
-      />
-    {/if}
+    </div>
 
     <AgentActivityBar
       running={activitySummary.running}
@@ -1445,6 +1449,27 @@ No need to mention in your report whether or not you used one of the fallback st
     flex: 1;
     display: flex;
     min-height: 0;
+  }
+
+  .mode-stack {
+    flex: 1;
+    position: relative;
+    min-height: 0;
+  }
+
+  .mode-layer {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    visibility: hidden;
+    pointer-events: none;
+    background: var(--bg-base);
+  }
+
+  .mode-layer.mode-visible {
+    visibility: visible;
+    pointer-events: auto;
+    z-index: 1;
   }
 
 </style>


### PR DESCRIPTION
## Summary
- Replace array-based message store with `Map<id, Message>` to avoid full re-renders on each chunk
- Add measured-height `VirtualScroller` component with binary search, `ResizeObserver`, and scroll anchoring
- Add markdown render cache to skip redundant `marked` + `DOMPurify` passes
- Switch Work/Plan app mode toggle from `{#if}`/`{:else}` (destroy/recreate) to `visibility` stacking so the entire component tree stays mounted and scroll position is preserved

## Test plan
- [ ] Open a workspace with 500+ messages — verify smooth scrolling with no lag
- [ ] Scroll to middle of chat, switch Work → Plan → Work — scroll position preserved
- [ ] Switch between workspaces — each preserves its own scroll position
- [ ] New messages while at bottom — auto-scrolls; while scrolled up — stays in place
- [ ] Kanban board has correct `--bg-base` background, no bleed-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)