### PR TITLE
fix: stay in Plan mode when starting a task from kanban

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -619,9 +619,7 @@ No need to mention in your report whether or not you used one of the fallback st
     };
     creatingWsId = tempId;
     workspaces.push(placeholder);
-    appMode = "work";
     selectWorkspace(tempId);
-    activeTab = "chat";
 
     try {
       const ws = await createWorkspace(repoId);


### PR DESCRIPTION
## Summary
- Removed the forced `appMode = "work"` and `activeTab = "chat"` switches when starting a task from the kanban board
- Starting a task now creates the workspace and sends the message in the background while the user stays in Plan mode

## Test plan
- [ ] Open Plan mode, create a todo, click Start — verify the app stays in Plan mode
- [ ] Verify the workspace is created and the message is sent correctly in the background
- [ ] Verify clicking a workspace card in kanban still switches to Work mode as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)