### PR TITLE
fix: display task title and description on workspace cards

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -605,6 +605,8 @@ pub fn set_repo_profile(
 #[tauri::command]
 pub async fn create_workspace(
     repo_id: String,
+    task_title: Option<String>,
+    task_description: Option<String>,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<WorkspaceInfo, String> {
     let (repo_path, gh_profile) = {
@@ -761,6 +763,8 @@ pub async fn create_workspace(
         gh_profile,
         status: WorkspaceStatus::Waiting,
         created_at: now_unix(),
+        task_title,
+        task_description,
     };
 
     // Check if there's a setup script to run

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -28,6 +28,10 @@ pub struct WorkspaceInfo {
     pub gh_profile: Option<String>,
     pub status: WorkspaceStatus,
     pub created_at: u64,
+    #[serde(default)]
+    pub task_title: Option<String>,
+    #[serde(default)]
+    pub task_description: Option<String>,
 }
 
 pub struct AgentHandle {
@@ -105,6 +109,7 @@ impl AppState {
             // Use Value to handle the old "archived" status that no longer deserializes
             let raw: Vec<serde_json::Value> =
                 serde_json::from_str(&data).map_err(|e| e.to_string())?;
+            let mut needs_persist = false;
             for entry in raw {
                 let status = entry.get("status").and_then(|s| s.as_str()).unwrap_or("");
                 if status == "archived" {
@@ -122,7 +127,18 @@ impl AppState {
                 if ws.status == WorkspaceStatus::Running {
                     ws.status = WorkspaceStatus::Waiting;
                 }
+                // Migration: backfill task_title from the first hidden user message
+                if ws.task_title.is_none() {
+                    if let Some((title, desc)) = extract_task_from_messages(&self.messages_dir(), &ws.id) {
+                        ws.task_title = Some(title);
+                        ws.task_description = desc;
+                        needs_persist = true;
+                    }
+                }
                 self.workspaces.insert(ws.id.clone(), ws);
+            }
+            if needs_persist {
+                self.save_workspaces()?;
             }
         }
 
@@ -219,6 +235,35 @@ impl AppState {
             return Err(format!("{} is not a git repository", path.display()));
         }
         Ok(())
+    }
+}
+
+/// Extract task title/description from the first hidden user message in a workspace's messages file.
+fn extract_task_from_messages(messages_dir: &Path, workspace_id: &str) -> Option<(String, Option<String>)> {
+    let path = messages_dir.join(format!("{}.json", workspace_id));
+    let data = std::fs::read_to_string(&path).ok()?;
+    let messages: Vec<serde_json::Value> = serde_json::from_str(&data).ok()?;
+
+    // Find first hidden user message
+    let msg = messages.iter().find(|m| {
+        m.get("role").and_then(|r| r.as_str()) == Some("user")
+            && m.get("hidden").and_then(|h| h.as_bool()) == Some(true)
+    })?;
+
+    // Extract text from chunks[0].content
+    let chunks = msg.get("chunks")?.as_array()?;
+    let content = chunks.first()?.get("content")?.as_str()?;
+    if content.is_empty() {
+        return None;
+    }
+
+    // Split on first double newline: title \n\n description
+    if let Some(pos) = content.find("\n\n") {
+        let title = content[..pos].to_string();
+        let desc = content[pos + 2..].trim().to_string();
+        Some((title, if desc.is_empty() { None } else { Some(desc) }))
+    } else {
+        Some((content.to_string(), None))
     }
 }
 

--- a/src/lib/components/KanbanCard.svelte
+++ b/src/lib/components/KanbanCard.svelte
@@ -93,20 +93,23 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="card ws-card" onclick={onClick}>
-    <div class="card-top">
+    <div class="card-top" class:has-title={!!workspace.task_title}>
       <span
         class="ws-dot"
         class:running={workspace.status === "running" && !isReviewing}
         class:reviewing={isReviewing}
         class:creating={isCreating}
       ></span>
-      <span class="card-name">{workspace.name}</span>
+      <span class="card-name" class:has-title={!!workspace.task_title}>{workspace.task_title ?? workspace.name}</span>
       {#if workspace.status === "running" && !isReviewing}
         <span class="card-elapsed">{elapsed}</span>
       {/if}
     </div>
+    {#if workspace.task_description}
+      <div class="card-task-desc">{workspace.task_description}</div>
+    {/if}
     <div class="card-bottom">
-      <span class="card-branch">{workspace.name !== workspace.branch ? workspace.branch : ""}</span>
+      <span class="card-branch">{workspace.task_title ? workspace.branch : (workspace.name !== workspace.branch ? workspace.branch : "")}</span>
       {#if changeCounts && (changeCounts.additions > 0 || changeCounts.deletions > 0)}
         <span class="card-diff">
           <span class="diff-add">+{changeCounts.additions}</span>
@@ -246,6 +249,14 @@
     gap: 0.4rem;
   }
 
+  .card-top.has-title {
+    align-items: flex-start;
+  }
+
+  .card-top.has-title .ws-dot {
+    margin-top: 0.35rem;
+  }
+
   .ws-dot {
     width: 6px;
     height: 6px;
@@ -289,11 +300,39 @@
     white-space: nowrap;
   }
 
+  .card-name.has-title {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--text-bright);
+    line-height: 1.3;
+    word-break: break-word;
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
   .card-elapsed {
     font-size: 0.65rem;
     color: var(--text-dim);
     font-family: var(--font-mono);
     flex-shrink: 0;
+  }
+
+  .card-task-desc {
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    line-height: 1.35;
+    white-space: pre-wrap;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    margin-top: 0.2rem;
+    padding-left: calc(6px + 0.4rem);
   }
 
   .card-bottom {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -26,6 +26,8 @@ export interface WorkspaceInfo {
   gh_profile: string | null;
   status: "running" | "waiting";
   created_at: number;
+  task_title?: string | null;
+  task_description?: string | null;
 }
 
 export interface ToolUseInfo {
@@ -82,8 +84,14 @@ export async function setRepoProfile(
 
 export async function createWorkspace(
   repoId: string,
+  taskTitle?: string,
+  taskDescription?: string,
 ): Promise<WorkspaceInfo> {
-  return invoke<WorkspaceInfo>("create_workspace", { repoId });
+  return invoke<WorkspaceInfo>("create_workspace", {
+    repoId,
+    taskTitle: taskTitle ?? null,
+    taskDescription: taskDescription ?? null,
+  });
 }
 
 export async function removeWorkspace(workspaceId: string): Promise<void> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -617,13 +617,15 @@ No need to mention in your report whether or not you used one of the fallback st
       gh_profile: null,
       status: "waiting",
       created_at: Date.now() / 1000,
+      task_title: todo.title,
+      task_description: todo.description || null,
     };
     creatingWsId = tempId;
     workspaces.push(placeholder);
     selectWorkspace(tempId);
 
     try {
-      const ws = await createWorkspace(repoId);
+      const ws = await createWorkspace(repoId, todo.title, todo.description || undefined);
       const idx = workspaces.findIndex((w) => w.id === tempId);
       if (idx >= 0) workspaces[idx] = ws;
       selectedWsId = ws.id;


### PR DESCRIPTION
## Summary
- Workspace cards in IN PROGRESS, REVIEW, and DONE columns now display the task title and description (matching TODO card style), while keeping the status dot and diff stats
- Added `task_title` and `task_description` fields to `WorkspaceInfo` (Rust + TS), passed through `create_workspace` when spawning from a todo
- Includes a one-time migration that backfills existing workspaces from the first hidden message in their messages file, persisted immediately to avoid re-running on every launch

## Test plan
- [ ] Create a workspace from a TODO with title + description — verify card shows both
- [ ] Verify existing workspaces (created before this change) show backfilled titles after restart
- [ ] Verify workspaces created directly (not from TODO) still show branch name as before
- [ ] Restart app twice — confirm migration only runs once (check logs for absence of backfill on second launch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)