### PR TITLE
fix: align chat message blocks with flex column layout

### DIFF
--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -977,6 +977,8 @@
   }
 
   .virtual-block {
+    display: flex;
+    flex-direction: column;
     padding: 0 1.25rem;
   }
 


### PR DESCRIPTION
## Summary
- User messages and system action messages were all left-aligned instead of right/center
- Root cause: `.virtual-block` container was missing `display: flex; flex-direction: column`, so `align-self` on child elements had no effect
- Added flex layout to `.virtual-block` to restore correct alignment (user → right, system → center, assistant → left)

## Test plan
- [ ] Verify user messages appear right-aligned
- [ ] Verify system/action messages (e.g. "Committing & pushing changes") appear centered
- [ ] Verify assistant messages remain left-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)