### PR TITLE
fix: pass success type to toast notifications for git operations

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -966,7 +966,7 @@ No need to mention in your report whether or not you used one of the fallback st
           const msg = await generateCommitMessage(wsId);
           await gitCommit(wsId, msg);
           await gitPush(wsId);
-          addToast("Pushed successfully");
+          addToast("Pushed successfully", "success");
           refreshChangeCounts(wsId);
           refreshPrStatus(wsId);
         } catch (e) {
@@ -985,7 +985,7 @@ No need to mention in your report whether or not you used one of the fallback st
         addActionMessage(wsId, crypto.randomUUID(), `Pushing to PR #${pr.number}`);
         try {
           await gitPush(wsId);
-          addToast("Pushed successfully");
+          addToast("Pushed successfully", "success");
           refreshPrStatus(wsId);
         } catch (e) {
           addToast(String(e));
@@ -1002,7 +1002,7 @@ No need to mention in your report whether or not you used one of the fallback st
       addActionMessage(wsId, crypto.randomUUID(), `Merging PR #${pr.number}`);
       try {
         await ghPrMerge(wsId, pr.number);
-        addToast(`PR #${pr.number} merged`);
+        addToast(`PR #${pr.number} merged`, "success");
         refreshPrStatus(wsId);
       } catch (e) {
         addToast(String(e));


### PR DESCRIPTION
## Summary
- Success toasts for push and merge operations were displaying in red (error color) because `addToast` defaults to `"error"` type
- Added explicit `"success"` type to the three affected call sites: two "Pushed successfully" and one "PR merged" toast

## Test plan
- [ ] Push changes to a PR and verify the toast appears in olive green, not red
- [ ] Merge a PR and verify the toast appears in olive green

🤖 Generated with [Claude Code](https://claude.com/claude-code)