### PR TITLE
fix: swap Plan and Work mode button order and shortcuts

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -104,11 +104,11 @@
       </button>
     </div>
     <div class="mode-switcher">
-      <button class="mode-btn" class:active={appMode === "work"} onclick={() => onModeChange("work")}>
-        Work <kbd class="mode-hint">⌘1</kbd>
-      </button>
       <button class="mode-btn" class:active={appMode === "plan"} onclick={() => onModeChange("plan")}>
-        Plan <kbd class="mode-hint">⌘2</kbd>
+        Plan <kbd class="mode-hint">⌘1</kbd>
+      </button>
+      <button class="mode-btn" class:active={appMode === "work"} onclick={() => onModeChange("work")}>
+        Work <kbd class="mode-hint">⌘2</kbd>
       </button>
     </div>
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -413,11 +413,11 @@ No need to mention in your report whether or not you used one of the fallback st
           break;
         case "1":
           e.preventDefault();
-          appMode = "work";
+          appMode = "plan";
           break;
         case "2":
           e.preventDefault();
-          appMode = "plan";
+          appMode = "work";
           break;
       }
     }


### PR DESCRIPTION
## Summary
- Moves Plan pill to the left (⌘1) and Work pill to the right (⌘2) in the titlebar mode switcher
- Updates keyboard shortcut bindings to match the new order

Plan-first ordering matches our primary workflow of planning in kanban before working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)