### PR TITLE
feat: add Update Branch button to pull base branch changes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1406,6 +1406,140 @@ pub async fn git_push(
     .map_err(|e| format!("Task failed: {}", e))?
 }
 
+// ── Base branch update detection & merge ─────────────────────────────
+
+#[derive(Clone, serde::Serialize)]
+pub struct BaseUpdateStatus {
+    pub behind_by: i64,
+}
+
+#[tauri::command]
+pub async fn check_base_updates(
+    workspace_id: String,
+    state: State<'_, Arc<Mutex<AppState>>>,
+) -> Result<BaseUpdateStatus, String> {
+    let (worktree_path, base_branch, gh_profile) = {
+        let st = state.lock().map_err(|e| e.to_string())?;
+        let ws = st.workspaces.get(&workspace_id).ok_or("Workspace not found")?;
+        let repo = st.repos.get(&ws.repo_id).ok_or("Repo not found")?;
+        let base = repo.default_branch.clone().unwrap_or_else(|| "main".to_string());
+        (ws.worktree_path.clone(), base, repo.gh_profile.clone())
+    };
+
+    let gh_token = resolve_gh_token(&gh_profile);
+
+    tauri::async_runtime::spawn_blocking(move || {
+        // Fetch latest from origin for the base branch
+        let mut fetch_cmd = git_cmd_with_auth(&worktree_path, &gh_token);
+        fetch_cmd.args(["fetch", "origin", &base_branch]);
+        fetch_cmd
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let _ = fetch_cmd.output(); // Best-effort; if offline we still compare stale refs
+
+        let remote_base = format!("origin/{}", base_branch);
+
+        // Find merge-base between HEAD and origin/<base>
+        let merge_base_output = std::process::Command::new("git")
+            .args(["merge-base", "HEAD", &remote_base])
+            .current_dir(&worktree_path)
+            .output()
+            .map_err(|e| format!("Failed to run git merge-base: {}", e))?;
+
+        if !merge_base_output.status.success() {
+            // No common ancestor — treat as 0 behind
+            return Ok(BaseUpdateStatus { behind_by: 0 });
+        }
+
+        let merge_base = String::from_utf8_lossy(&merge_base_output.stdout)
+            .trim()
+            .to_string();
+
+        // Count commits on origin/<base> since the merge-base
+        let rev_list = std::process::Command::new("git")
+            .args(["rev-list", "--count", &format!("{}..{}", merge_base, remote_base)])
+            .current_dir(&worktree_path)
+            .output()
+            .map_err(|e| format!("Failed to count commits: {}", e))?;
+
+        let behind_by = if rev_list.status.success() {
+            String::from_utf8_lossy(&rev_list.stdout)
+                .trim()
+                .parse::<i64>()
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        Ok(BaseUpdateStatus { behind_by })
+    })
+    .await
+    .map_err(|e| format!("Task failed: {}", e))?
+}
+
+#[tauri::command]
+pub async fn update_from_base(
+    workspace_id: String,
+    state: State<'_, Arc<Mutex<AppState>>>,
+) -> Result<(), String> {
+    let (worktree_path, base_branch, gh_profile) = {
+        let st = state.lock().map_err(|e| e.to_string())?;
+        let ws = st.workspaces.get(&workspace_id).ok_or("Workspace not found")?;
+        let repo = st.repos.get(&ws.repo_id).ok_or("Repo not found")?;
+        let base = repo.default_branch.clone().unwrap_or_else(|| "main".to_string());
+        (ws.worktree_path.clone(), base, repo.gh_profile.clone())
+    };
+
+    let gh_token = resolve_gh_token(&gh_profile);
+
+    tauri::async_runtime::spawn_blocking(move || {
+        // Fetch latest
+        let mut fetch_cmd = git_cmd_with_auth(&worktree_path, &gh_token);
+        fetch_cmd.args(["fetch", "origin", &base_branch]);
+        let fetch_output = fetch_cmd
+            .output()
+            .map_err(|e| format!("Failed to fetch: {}", e))?;
+        if !fetch_output.status.success() {
+            let stderr = String::from_utf8_lossy(&fetch_output.stderr);
+            return Err(format!(
+                "git fetch failed: {}",
+                stderr.trim()
+            ));
+        }
+
+        // Merge origin/<base> into the workspace branch
+        let remote_base = format!("origin/{}", base_branch);
+        let merge_output = std::process::Command::new("git")
+            .args(["merge", &remote_base, "--no-edit"])
+            .current_dir(&worktree_path)
+            .output()
+            .map_err(|e| format!("Failed to run git merge: {}", e))?;
+
+        if !merge_output.status.success() {
+            let stderr = String::from_utf8_lossy(&merge_output.stderr);
+            let stdout = String::from_utf8_lossy(&merge_output.stdout);
+
+            // Abort the failed merge to leave worktree clean
+            let _ = std::process::Command::new("git")
+                .args(["merge", "--abort"])
+                .current_dir(&worktree_path)
+                .output();
+
+            if stderr.contains("CONFLICT") || stdout.contains("CONFLICT") {
+                return Err(format!(
+                    "Merge conflicts detected when updating from {}. The merge has been aborted.",
+                    base_branch
+                ));
+            }
+            return Err(format!("git merge failed: {}", stderr.trim()));
+        }
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task failed: {}", e))?
+}
+
 #[tauri::command]
 pub async fn gh_pr_merge(
     workspace_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,8 @@ pub fn run() {
             commands::set_repo_profile,
             commands::git_commit,
             commands::git_push,
+            commands::check_base_updates,
+            commands::update_from_base,
             commands::gh_pr_merge,
             commands::generate_commit_message,
             commands::get_pr_status,

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -4,7 +4,7 @@
   import type { ReviewState } from "$lib/components/ReviewPill.svelte";
   import type { ChatPanelApi, QueueDisplayItem, PastedImage } from "$lib/components/ChatPanel.svelte";
   import type { Mention } from "$lib/components/MentionInput.svelte";
-  import { ExternalLink, Check, Loader, GitPullRequestCreate, GitMerge, ArrowUp, AlertTriangle, Wrench, Eye } from "lucide-svelte";
+  import { ExternalLink, Check, Loader, GitPullRequestCreate, GitMerge, ArrowUp, ArrowDown, AlertTriangle, Wrench, Eye } from "lucide-svelte";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import ChatPanel from "$lib/components/ChatPanel.svelte";
   import DiffViewer from "$lib/components/DiffViewer.svelte";
@@ -29,7 +29,10 @@
     diffRefreshTrigger: number;
     prStatus: PrStatus | undefined;
     wsChanges: { additions: number; deletions: number } | undefined;
+    baseBehindBy: number;
+    updatingBranch: boolean;
     onPrAction: () => void;
+    onUpdateBranch: () => void;
     onReview: () => void;
     reviewRunning: boolean;
     operationInProgress: boolean;
@@ -61,7 +64,10 @@
     diffRefreshTrigger,
     prStatus,
     wsChanges,
+    baseBehindBy,
+    updatingBranch,
     onPrAction,
+    onUpdateBranch,
     onReview,
     reviewRunning,
     operationInProgress,
@@ -106,6 +112,17 @@
       </div>
 
       <div class="tab-actions">
+        {#if baseBehindBy > 0}
+          <button
+            class="action-badge update-branch"
+            onclick={onUpdateBranch}
+            disabled={isBusy || updatingBranch}
+            title="Merge {baseBehindBy} new commit{baseBehindBy === 1 ? '' : 's'} from base branch"
+          >
+            {#if updatingBranch}<Loader size={11} class="status-icon spinning" />{:else}<ArrowDown size={11} />{/if}
+            Update{#if !updatingBranch}&nbsp;<span class="update-count">{baseBehindBy}</span>{/if}
+          </button>
+        {/if}
         {#if prStatus?.state === "open"}
           <div class="action-group">
             <button class="pr-link-btn" onclick={() => openUrl(prStatus!.url)} title="Open PR #{prStatus.number} in browser">
@@ -396,6 +413,23 @@
   .action-badge.review:hover:not(:disabled) {
     color: var(--text-primary);
     background: var(--border);
+  }
+
+  .action-badge.update-branch {
+    color: var(--text-secondary);
+    border-color: var(--border-light);
+    background: var(--bg-card);
+  }
+
+  .action-badge.update-branch:hover:not(:disabled) {
+    color: var(--text-primary);
+    background: var(--border);
+  }
+
+  .update-count {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    opacity: 0.7;
   }
 
   .action-badge.conflicts {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -251,6 +251,22 @@ export async function getDiff(
   return invoke<string>("get_diff", { workspaceId, filePath });
 }
 
+// ── Base Branch Updates ─────────────────────────────────────────────
+
+export interface BaseUpdateStatus {
+  behind_by: number;
+}
+
+export async function checkBaseUpdates(
+  workspaceId: string,
+): Promise<BaseUpdateStatus> {
+  return invoke<BaseUpdateStatus>("check_base_updates", { workspaceId });
+}
+
+export async function updateFromBase(workspaceId: string): Promise<void> {
+  return invoke("update_from_base", { workspaceId });
+}
+
 // ── Direct Git/GH Operations ────────────────────────────────────────
 
 export interface CommitResult {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,8 @@
     gitPush,
     ghPrMerge,
     generateCommitMessage,
+    checkBaseUpdates,
+    updateFromBase,
     saveTodos,
     loadTodos,
     type RepoDetail,
@@ -229,6 +231,8 @@ No need to mention in your report whether or not you used one of the fallback st
   let chatPanelApis = new SvelteMap<string, ChatPanelApi>();
   let reviewByWorkspace = new SvelteMap<string, ReviewState>();
   let gitOpInProgress = new SvelteMap<string, boolean>();
+  let baseBehindMap = new SvelteMap<string, number>();
+  let updatingBranchMap = new SvelteMap<string, boolean>();
   let titleBarRef: TitleBar | undefined = $state();
   let repoDropdownIndex = $state(-1);
 
@@ -325,6 +329,8 @@ No need to mention in your report whether or not you used one of the fallback st
             pendingDrain.delete(event.workspace_id);
             drainQueue(event.workspace_id);
           }
+          // Agent finished — check if base branch moved ahead while it was working
+          refreshBaseUpdates(event.workspace_id);
         }
       });
 
@@ -432,10 +438,17 @@ No need to mention in your report whether or not you used one of the fallback st
       }
     }, 5_000);
 
+    // Check base branch updates every 60s for the selected workspace.
+    // Lighter touch than PR polling since it involves a `git fetch`.
+    const basePollInterval = setInterval(() => {
+      if (selectedWsId) refreshBaseUpdates(selectedWsId);
+    }, 60_000);
+
     return () => {
       unlistenStatus?.();
       unlistenWsUpdate?.();
       clearInterval(prPollInterval);
+      clearInterval(basePollInterval);
       window.removeEventListener("keydown", handleKeydown);
     };
   });
@@ -499,6 +512,8 @@ No need to mention in your report whether or not you used one of the fallback st
       prStatusMap.clear();
       clearPrStatusCacheForRepo(removedWsIds);
       changeCounts.clear();
+      baseBehindMap.clear();
+      updatingBranchMap.clear();
       planModeByWorkspace.clear();
       thinkingModeByWorkspace.clear();
       todos = [];
@@ -678,6 +693,7 @@ No need to mention in your report whether or not you used one of the fallback st
     appMode = "work";
     activeTab = "chat";
     refreshPrStatus(wsId);
+    refreshBaseUpdates(wsId);
   }
 
   // ── Workspace handlers ────────────────────────────────
@@ -707,6 +723,8 @@ No need to mention in your report whether or not you used one of the fallback st
     prStatusMap.delete(wsId);
     removePrStatusCacheEntry(wsId);
     changeCounts.delete(wsId);
+    baseBehindMap.delete(wsId);
+    updatingBranchMap.delete(wsId);
     planModeByWorkspace.delete(wsId);
     thinkingModeByWorkspace.delete(wsId);
 
@@ -1197,10 +1215,53 @@ No need to mention in your report whether or not you used one of the fallback st
     }
   }
 
+  // Check if base branch has new commits since workspace branched off.
+  // Only triggers reactivity when behind_by actually changes.
+  async function refreshBaseUpdates(wsId: string) {
+    try {
+      const status = await checkBaseUpdates(wsId);
+      const prev = baseBehindMap.get(wsId);
+      if (prev === status.behind_by) return;
+      baseBehindMap.set(wsId, status.behind_by);
+    } catch {
+      // Offline or git error — non-critical
+    }
+  }
+
+  async function handleUpdateBranch() {
+    if (!selectedWs || !activeRepo) return;
+    const wsId = selectedWs.id;
+    if (updatingBranchMap.get(wsId)) return;
+
+    updatingBranchMap.set(wsId, true);
+    try {
+      await updateFromBase(wsId);
+      addToast("Branch updated from " + activeRepo.default_branch);
+      baseBehindMap.set(wsId, 0);
+      refreshChangeCounts(wsId);
+      diffRefreshTrigger++;
+    } catch (e) {
+      const errMsg = String(e);
+      if (errMsg.includes("conflicts")) {
+        addToast("Merge conflicts — delegating to agent");
+        const baseBranch = activeRepo.default_branch;
+        sendPrompt(wsId, `Updating from ${baseBranch} caused merge conflicts. The automatic merge was aborted.\n\nPlease resolve this:\n1. Run \`git fetch origin ${baseBranch}\`\n2. Run \`git merge origin/${baseBranch}\`\n3. Resolve all conflicts\n4. Commit the merge\n\nIf the conflicts are complex, explain what's conflicting before resolving.`, `Resolving merge conflicts with ${baseBranch}`);
+        activeTab = "chat";
+      } else {
+        addToast(errMsg);
+      }
+    } finally {
+      updatingBranchMap.delete(wsId);
+      // Re-check in case the merge resolved or changed the count
+      refreshBaseUpdates(wsId);
+    }
+  }
+
   function selectWorkspace(wsId: string) {
     selectedWsId = wsId;
     // Refresh PR status in background so it's current when the user lands on the workspace
     refreshPrStatus(wsId);
+    refreshBaseUpdates(wsId);
   }
 </script>
 
@@ -1284,7 +1345,10 @@ No need to mention in your report whether or not you used one of the fallback st
             {diffRefreshTrigger}
             prStatus={selectedWsId ? prStatusMap.get(selectedWsId) : undefined}
             wsChanges={selectedWsId ? changeCounts.get(selectedWsId) : undefined}
+            baseBehindBy={selectedWsId ? baseBehindMap.get(selectedWsId) ?? 0 : 0}
+            updatingBranch={selectedWsId ? updatingBranchMap.get(selectedWsId) ?? false : false}
             onPrAction={handlePrAction}
+            onUpdateBranch={handleUpdateBranch}
             onReview={handleReview}
             reviewRunning={selectedWsId ? reviewByWorkspace.get(selectedWsId)?.status === "running" : false}
             operationInProgress={selectedWsId ? gitOpInProgress.get(selectedWsId) ?? false : false}


### PR DESCRIPTION
## Summary

- Adds two new Tauri commands (`check_base_updates`, `update_from_base`) that fetch the base branch and detect/merge upstream changes
- Shows an "Update" button with commit count badge in the workspace tab bar when the base branch is ahead
- On merge conflict, auto-aborts and delegates resolution to the agent via chat
- Polls for base updates every 60s on the active workspace and on agent completion

## Test plan

- [ ] Create a workspace, push commits to main from another source, verify the Update button appears
- [ ] Click Update — verify merge succeeds and button disappears
- [ ] Create a conflicting change, click Update — verify merge aborts and agent is prompted to resolve
- [ ] Verify button is disabled while agent is running
- [ ] Switch workspaces and verify the count refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)