### PR TITLE
fix: enable asset protocol for plan card images

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1700,6 +1700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,6 +4011,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$APPDATA/images/**"]
+      }
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- Plan mode TODO card images showed broken icons after clicking "Add" because `convertFileSrc()` URLs had no backing protocol handler
- The Tauri v2 asset protocol is disabled by default (`enable: false`); enabled it and scoped to `$APPDATA/images/**`
- Pasting worked (uses inline data URLs) but saved-to-disk images failed — this fixes both card display and edit dialog thumbnails

## Test plan
- [ ] Paste an image in the task popover, verify thumbnail shows
- [ ] Click Add, verify the TODO card shows the image thumbnail (not broken icon)
- [ ] Click Edit on that card, verify the edit dialog also shows the thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)