### PR TITLE
fix: swap plan/work mode order so Plan is first (⌘1)

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -104,11 +104,11 @@
       </button>
     </div>
     <div class="mode-switcher">
-      <button class="mode-btn" class:active={appMode === "work"} onclick={() => onModeChange("work")}>
-        Work <kbd class="mode-hint">⌘1</kbd>
-      </button>
       <button class="mode-btn" class:active={appMode === "plan"} onclick={() => onModeChange("plan")}>
-        Plan <kbd class="mode-hint">⌘2</kbd>
+        Plan <kbd class="mode-hint">⌘1</kbd>
+      </button>
+      <button class="mode-btn" class:active={appMode === "work"} onclick={() => onModeChange("work")}>
+        Work <kbd class="mode-hint">⌘2</kbd>
       </button>
     </div>
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -413,11 +413,11 @@ No need to mention in your report whether or not you used one of the fallback st
           break;
         case "1":
           e.preventDefault();
-          appMode = "work";
+          appMode = "plan";
           break;
         case "2":
           e.preventDefault();
-          appMode = "plan";
+          appMode = "work";
           break;
       }
     }


### PR DESCRIPTION
## Summary
- Swaps the Plan and Work pill order in the title bar so Plan appears first
- Updates keyboard shortcuts to match: ⌘1 → Plan, ⌘2 → Work
- Aligns with our primary workflow of planning first in kanban

## Test plan
- [ ] Verify Plan pill appears before Work pill in the title bar
- [ ] Verify ⌘1 switches to Plan mode, ⌘2 switches to Work mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)