### PR TITLE
feat: show task title above branch name in sidebar workspace list

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -142,7 +142,14 @@
                   autofocus
                 />
               {:else}
-                <span class="ws-name" class:creating-name={ws.id === creatingWsId}>{ws.name}</span>
+                {#if ws.task_title}
+                  <span class="ws-info" class:creating-name={ws.id === creatingWsId}>
+                    <span class="ws-title">{ws.task_title}</span>
+                    <span class="ws-branch">{ws.name}</span>
+                  </span>
+                {:else}
+                  <span class="ws-name" class:creating-name={ws.id === creatingWsId}>{ws.name}</span>
+                {/if}
                 {#if ws.id !== creatingWsId && reviewingWsIds.has(ws.id)}
                   <span class="ws-reviewing"><Eye size={11} /></span>
                 {:else if ws.id !== creatingWsId && ws.status === "running"}
@@ -421,6 +428,36 @@
 
   @keyframes spin {
     to { transform: rotate(360deg); }
+  }
+
+  .ws-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    overflow: hidden;
+  }
+
+  .ws-info.creating-name .ws-title {
+    color: var(--text-dim);
+    font-style: italic;
+  }
+
+  .ws-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.8rem;
+    color: var(--text-primary);
+  }
+
+  .ws-branch {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.68rem;
+    color: var(--text-dim);
+    opacity: 0.7;
   }
 
   .ws-name {


### PR DESCRIPTION
## Summary
- Sidebar workspace items now show a two-line layout: task title (primary) with branch name below it (secondary, smaller/dimmer)
- Workspaces without a `task_title` fall back to the existing single-line branch name display
- No backend changes needed — `task_title` was already wired end-to-end and persisted

## Test plan
- [ ] Verify workspaces with a `task_title` show two lines in the sidebar
- [ ] Verify workspaces without a `task_title` still show single-line branch name
- [ ] Verify text truncation with ellipsis works for long titles and branch names
- [ ] Verify creating-state styling still applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)