### PR TITLE
fix: open markdown links in system browser instead of Tauri webview

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,0 +1,17 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+/** Svelte action: intercepts <a> clicks inside the node and opens them in the system browser. */
+export function externalLinks(node: HTMLElement) {
+  function handleClick(e: MouseEvent) {
+    const anchor = (e.target as HTMLElement).closest("a");
+    if (!anchor || !anchor.href) return;
+    e.preventDefault();
+    openUrl(anchor.href);
+  }
+  node.addEventListener("click", handleClick);
+  return {
+    destroy() {
+      node.removeEventListener("click", handleClick);
+    },
+  };
+}

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -3,6 +3,7 @@
   import { searchWorkspaceFiles, type FileSearchResult } from "$lib/ipc";
   import { FileText, Pencil, FilePlus, Terminal, FolderSearch, TextSearch, Bot, Globe, Zap, Settings, Lightbulb, BookOpen, Play, ArrowUp, Square, MessageCircleQuestion, Loader2, Timer } from "lucide-svelte";
   import { renderMarkdown } from "$lib/markdown";
+  import { externalLinks } from "$lib/actions";
   import MentionInput, { type Mention, type MentionInputValue, type MentionInputApi } from "./MentionInput.svelte";
   import MentionAutocomplete, { type MentionAutocompleteApi } from "./MentionAutocomplete.svelte";
   import VirtualScroller from "./VirtualScroller.svelte";
@@ -589,7 +590,7 @@
             {:else if block.kind === "text"}
               <div class="assistant-msg">
                 <div class="assistant-card">
-                  <div class="assistant-text markdown-body">{@html renderMarkdown(block.chunk.content)}</div>
+                  <div class="assistant-text markdown-body" use:externalLinks>{@html renderMarkdown(block.chunk.content)}</div>
                 </div>
               </div>
             {:else if block.kind === "tool-group"}

--- a/src/lib/components/ReviewPill.svelte
+++ b/src/lib/components/ReviewPill.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { renderMarkdown } from "$lib/markdown";
+  import { externalLinks } from "$lib/actions";
   import { CircleCheck, CircleX, Loader2, X } from "lucide-svelte";
 
   export interface ReviewState {
@@ -79,7 +80,7 @@
         <X size={12} />
       </button>
     </div>
-    <div class="pill-body">
+    <div class="pill-body" use:externalLinks>
       {@html renderedHtml}
     </div>
     <div class="pill-footer">


### PR DESCRIPTION
## Summary
- Markdown links in ChatPanel and ReviewPill now open in the user's system browser instead of navigating the Tauri webview
- Adds a reusable `externalLinks` Svelte action that intercepts `<a>` clicks via event delegation and routes them through `@tauri-apps/plugin-opener`

## Test plan
- [ ] Click a markdown link in an assistant chat message — should open in system browser
- [ ] Click a markdown link in a review pill — should open in system browser
- [ ] Verify non-link clicks in markdown still work normally (text selection, code copy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)