### PR TITLE
feat: add resizable sidebars with shared ResizeHandle component

### DIFF
--- a/src/lib/components/DiffViewer.svelte
+++ b/src/lib/components/DiffViewer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getChangedFiles, getDiff, type ChangedFile } from "$lib/ipc";
+  import ResizeHandle from "./ResizeHandle.svelte";
 
   interface Props {
     workspaceId: string;
@@ -136,6 +137,14 @@
     return parts.slice(0, -1).join("/") + "/";
   }
 
+  let fileSidebarWidth = $state(240);
+  const FILE_SIDEBAR_MIN = 140;
+  const FILE_SIDEBAR_MAX = 500;
+
+  function handleFileSidebarResize(delta: number) {
+    fileSidebarWidth = Math.min(FILE_SIDEBAR_MAX, Math.max(FILE_SIDEBAR_MIN, fileSidebarWidth + delta));
+  }
+
   function statusIcon(status: string): string {
     switch (status) {
       case "A": return "+";
@@ -158,7 +167,7 @@
   {:else}
     <div class="diff-layout">
       <!-- File sidebar -->
-      <div class="file-sidebar">
+      <div class="file-sidebar" style="width: {fileSidebarWidth}px">
         <div class="file-sidebar-header">
           <span class="file-count">Changes {files.length}</span>
           <span class="file-stat">
@@ -188,6 +197,7 @@
           {/each}
         </div>
       </div>
+      <ResizeHandle onResize={handleFileSidebarResize} />
 
       <!-- Diff content -->
       <div class="diff-content">
@@ -240,8 +250,6 @@
   /* ── File sidebar ──────────────────────── */
 
   .file-sidebar {
-    width: 240px;
-    border-right: 1px solid var(--border);
     display: flex;
     flex-direction: column;
     flex-shrink: 0;

--- a/src/lib/components/FileBrowser.svelte
+++ b/src/lib/components/FileBrowser.svelte
@@ -2,6 +2,7 @@
   import { SvelteSet } from "svelte/reactivity";
   import { Folder, FolderOpen, File as FileIcon } from "lucide-svelte";
   import { listDirectory, readFile, writeFile, type FileEntry } from "$lib/ipc";
+  import ResizeHandle from "./ResizeHandle.svelte";
 
   // ── Devicon imports (Vite resolves as URL strings) ──
   import iconRust from "devicon/icons/rust/rust-original.svg";
@@ -222,6 +223,14 @@
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
+  let treeWidth = $state(260);
+  const TREE_MIN = 140;
+  const TREE_MAX = 500;
+
+  function handleTreeResize(delta: number) {
+    treeWidth = Math.min(TREE_MAX, Math.max(TREE_MIN, treeWidth + delta));
+  }
+
   async function refreshTree() {
     rootLoading = true;
     rootError = "";
@@ -305,7 +314,7 @@
   {:else}
     <div class="browser-layout">
       <!-- File tree sidebar -->
-      <div class="tree-sidebar">
+      <div class="tree-sidebar" style="width: {treeWidth}px">
         <div class="tree-header">
           <span class="tree-title">Files</span>
           <button class="refresh-btn" onclick={refreshTree} title="Refresh">↻</button>
@@ -316,6 +325,7 @@
           {/each}
         </div>
       </div>
+      <ResizeHandle onResize={handleTreeResize} />
 
       <!-- File content -->
       <div class="file-content-area">
@@ -441,8 +451,6 @@
   /* ── Tree sidebar ───────────────────────── */
 
   .tree-sidebar {
-    width: 260px;
-    border-right: 1px solid var(--border);
     display: flex;
     flex-direction: column;
     flex-shrink: 0;

--- a/src/lib/components/ResizeHandle.svelte
+++ b/src/lib/components/ResizeHandle.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  interface Props {
+    /** Called with the incremental pixel delta since the last pointer move */
+    onResize: (delta: number) => void;
+    /** Called when the drag ends */
+    onResizeEnd?: () => void;
+    /** Orientation of the handle */
+    direction?: "horizontal" | "vertical";
+  }
+
+  let { onResize, onResizeEnd, direction = "horizontal" }: Props = $props();
+
+  let dragging = $state(false);
+  let startPos = 0;
+
+  function handlePointerDown(e: PointerEvent) {
+    e.preventDefault();
+    dragging = true;
+    startPos = direction === "horizontal" ? e.clientX : e.clientY;
+
+    const target = e.currentTarget as HTMLElement;
+    target.setPointerCapture(e.pointerId);
+  }
+
+  function handlePointerMove(e: PointerEvent) {
+    if (!dragging) return;
+    const current = direction === "horizontal" ? e.clientX : e.clientY;
+    const delta = current - startPos;
+    onResize(delta);
+    startPos = current;
+  }
+
+  function handlePointerUp(e: PointerEvent) {
+    if (!dragging) return;
+    dragging = false;
+    const target = e.currentTarget as HTMLElement;
+    try { target.releasePointerCapture(e.pointerId); } catch {}
+    onResizeEnd?.();
+  }
+</script>
+
+<div
+  class="resize-handle"
+  class:horizontal={direction === "horizontal"}
+  class:vertical={direction === "vertical"}
+  class:dragging
+  role="separator"
+  aria-orientation={direction}
+  onpointerdown={handlePointerDown}
+  onpointermove={handlePointerMove}
+  onpointerup={handlePointerUp}
+  onpointercancel={handlePointerUp}
+></div>
+
+<style>
+  .resize-handle {
+    flex-shrink: 0;
+    position: relative;
+    z-index: 10;
+    touch-action: none;
+  }
+
+  .resize-handle.horizontal {
+    width: 1px;
+    cursor: col-resize;
+    background: var(--border);
+  }
+
+  .resize-handle.vertical {
+    height: 1px;
+    cursor: row-resize;
+    background: var(--border);
+  }
+
+  /* Invisible wider hit area */
+  .resize-handle::after {
+    content: "";
+    position: absolute;
+  }
+
+  .resize-handle.horizontal::after {
+    top: 0;
+    bottom: 0;
+    left: -3px;
+    right: -3px;
+  }
+
+  .resize-handle.vertical::after {
+    left: 0;
+    right: 0;
+    top: -3px;
+    bottom: -3px;
+  }
+
+  .resize-handle:hover,
+  .resize-handle.dragging {
+    background: var(--accent);
+  }
+</style>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -2,6 +2,7 @@
   import type { WorkspaceInfo, PrStatus } from "$lib/ipc";
   import { Eye, ChevronRight } from "lucide-svelte";
   import { SvelteSet } from "svelte/reactivity";
+  import ResizeHandle from "./ResizeHandle.svelte";
 
   interface Props {
     workspaces: WorkspaceInfo[];
@@ -73,6 +74,14 @@
     }
   }
 
+  let sidebarWidth = $state(220);
+  const SIDEBAR_MIN = 140;
+  const SIDEBAR_MAX = 400;
+
+  function handleSidebarResize(delta: number) {
+    sidebarWidth = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, sidebarWidth + delta));
+  }
+
   let editingId = $state<string | null>(null);
   let editValue = $state("");
 
@@ -101,19 +110,20 @@
 
 <svelte:window onclick={handleWindowClick} />
 
-<aside class="sidebar">
-  <div class="workspace-list">
-    {#each groups as group}
-      <div class="group">
-        <button class="group-header" onclick={() => toggleGroup(group.key)}>
-          <span class="group-chevron" class:expanded={!collapsed.has(group.key)}>
-            <ChevronRight size={12} />
-          </span>
-          <span class="group-label">{group.label}</span>
-          <span class="group-count">{group.items.length}</span>
-        </button>
-        {#if !collapsed.has(group.key)}
-        {#each group.items as ws (ws.id)}
+<aside class="sidebar" style="width: {sidebarWidth}px">
+  <div class="sidebar-inner">
+    <div class="workspace-list">
+      {#each groups as group}
+        <div class="group">
+          <button class="group-header" onclick={() => toggleGroup(group.key)}>
+            <span class="group-chevron" class:expanded={!collapsed.has(group.key)}>
+              <ChevronRight size={12} />
+            </span>
+            <span class="group-label">{group.label}</span>
+            <span class="group-count">{group.items.length}</span>
+          </button>
+          {#if !collapsed.has(group.key)}
+          {#each group.items as ws (ws.id)}
           <div class="ws-item-wrap">
             <button
               class="ws-item"
@@ -171,19 +181,27 @@
           </div>
         {/each}
         {/if}
-      </div>
-    {/each}
+        </div>
+      {/each}
+    </div>
   </div>
+  <ResizeHandle onResize={handleSidebarResize} />
 </aside>
 
 <style>
   .sidebar {
-    width: 220px;
-    border-right: 1px solid var(--border);
+    border-right: none;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     background: var(--bg-sidebar);
     flex-shrink: 0;
+  }
+
+  .sidebar-inner {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
   }
 
   .workspace-list {


### PR DESCRIPTION
## Summary
- Adds a reusable `ResizeHandle.svelte` component using Pointer Events API with `setPointerCapture` for reliable drag tracking
- Integrates resizable sidebars into `Sidebar.svelte` (220px default, 140–400px), `FileBrowser.svelte` tree panel (260px default, 140–500px), and `DiffViewer.svelte` file list (240px default, 140–500px)
- Handle replaces previous `border-right` dividers and highlights with `--accent` on hover/drag

## Test plan
- [ ] Drag each sidebar handle and verify width clamps at min/max
- [ ] Verify no text selection artifacts during drag
- [ ] Confirm handle highlights on hover and during drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)