### PR TITLE
feat: add copy-to-clipboard button on code blocks in chat

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -15,3 +15,40 @@ export function externalLinks(node: HTMLElement) {
     },
   };
 }
+
+const COPY_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`;
+
+/** Svelte action: adds a copy button to each <pre> code block inside the node. */
+export function copyCodeBlocks(node: HTMLElement) {
+  const timers: number[] = [];
+
+  function addButtons() {
+    node.querySelectorAll("pre").forEach((pre) => {
+      if (pre.querySelector(".copy-code-btn")) return;
+      pre.style.position = "relative";
+      const btn = document.createElement("button");
+      btn.className = "copy-code-btn";
+      btn.innerHTML = COPY_ICON;
+      btn.title = "Copy";
+      btn.addEventListener("click", () => {
+        const code = pre.querySelector("code")?.textContent ?? pre.textContent ?? "";
+        navigator.clipboard.writeText(code);
+        btn.innerHTML = CHECK_ICON;
+        const t = window.setTimeout(() => { btn.innerHTML = COPY_ICON; }, 1500);
+        timers.push(t);
+      });
+      pre.appendChild(btn);
+    });
+  }
+
+  addButtons();
+
+  return {
+    update() { addButtons(); },
+    destroy() {
+      timers.forEach(clearTimeout);
+      node.querySelectorAll(".copy-code-btn").forEach((b) => b.remove());
+    },
+  };
+}

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -3,7 +3,7 @@
   import { searchWorkspaceFiles, type FileSearchResult } from "$lib/ipc";
   import { FileText, Pencil, FilePlus, Terminal, FolderSearch, TextSearch, Bot, Globe, Zap, Settings, Lightbulb, BookOpen, Play, ArrowUp, Square, MessageCircleQuestion, Loader2, Timer } from "lucide-svelte";
   import { renderMarkdown } from "$lib/markdown";
-  import { externalLinks } from "$lib/actions";
+  import { externalLinks, copyCodeBlocks } from "$lib/actions";
   import MentionInput, { type Mention, type MentionInputValue, type MentionInputApi } from "./MentionInput.svelte";
   import MentionAutocomplete, { type MentionAutocompleteApi } from "./MentionAutocomplete.svelte";
   import VirtualScroller from "./VirtualScroller.svelte";
@@ -590,7 +590,7 @@
             {:else if block.kind === "text"}
               <div class="assistant-msg">
                 <div class="assistant-card">
-                  <div class="assistant-text markdown-body" use:externalLinks>{@html renderMarkdown(block.chunk.content)}</div>
+                  <div class="assistant-text markdown-body" use:externalLinks use:copyCodeBlocks>{@html renderMarkdown(block.chunk.content)}</div>
                 </div>
               </div>
             {:else if block.kind === "tool-group"}
@@ -1208,6 +1208,34 @@
     padding: 0;
     font-size: 0.78rem;
     color: var(--text-primary);
+  }
+
+  .assistant-text.markdown-body :global(.copy-code-btn) {
+    position: absolute;
+    top: 0.35rem;
+    right: 0.35rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .assistant-text.markdown-body :global(pre:hover .copy-code-btn) {
+    opacity: 1;
+  }
+
+  .assistant-text.markdown-body :global(.copy-code-btn:hover) {
+    color: var(--text-bright);
+    border-color: var(--text-muted);
   }
 
   /* Tables */


### PR DESCRIPTION
## Summary
- Adds a copy button to `<pre>` code blocks in rendered markdown assistant messages
- Implemented as a Svelte action (`copyCodeBlocks`) in `src/lib/actions.ts` that injects buttons via DOM after `{@html}` render
- Button shows on hover with clipboard icon, switches to checkmark for 1.5s after copying

## Test plan
- [ ] Send a message that produces a code block in the assistant response
- [ ] Hover over the code block — copy button should appear top-right
- [ ] Click the button — code should be copied to clipboard, icon changes to checkmark
- [ ] Verify button disappears when not hovering

🤖 Generated with [Claude Code](https://claude.com/claude-code)