### PR TITLE
fix: stop propagation on Cmd+Enter in task popover to prevent double submission

### DIFF
--- a/src/lib/components/TaskPopover.svelte
+++ b/src/lib/components/TaskPopover.svelte
@@ -135,6 +135,7 @@
     }
     if (e.key === "Enter" && e.metaKey) {
       e.preventDefault();
+      e.stopPropagation();
       submit();
     }
   }
@@ -248,6 +249,7 @@
     // Cmd+Enter to submit
     if (e.key === "Enter" && e.metaKey) {
       e.preventDefault();
+      e.stopPropagation();
       submit();
     }
     // Escape to cancel


### PR DESCRIPTION
## Summary
- Cmd+Enter in the task popover's title input or description wrapper was calling `submit()` twice — once in the child handler, then again in the overlay's `handleOverlayKeydown` due to event bubbling
- Added `e.stopPropagation()` in both `handleTitleKeydown` and `handleDescKeydown` to prevent the event from reaching the overlay handler

## Test plan
- [ ] Open task popover from kanban board
- [ ] Type a title and press Cmd+Enter — verify only one task is created
- [ ] Focus the description field and press Cmd+Enter — verify only one task is created
- [ ] Verify Escape still closes the popover from both fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)