### PR TITLE
fix: suppress ResizeObserver loop warnings in terminal and layout

### DIFF
--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -17,6 +17,7 @@
   let resizeObserver: ResizeObserver | undefined;
   let colorSchemeQuery: MediaQueryList | undefined;
   let opened = false;
+  let fitRafId: number | undefined;
 
   const darkTheme = {
     background: "#12110e",
@@ -128,14 +129,24 @@
       if (!opened) {
         initTerminal();
       } else if (fitAddon && term) {
-        fitAddon.fit();
-        resizeTerminal(workspaceId, term.rows, term.cols).catch(() => {});
+        // Debounce fit() to next frame to avoid ResizeObserver loop warnings.
+        // fit() mutates the DOM which can trigger another resize notification
+        // in the same observation cycle — deferring breaks the loop.
+        if (fitRafId !== undefined) cancelAnimationFrame(fitRafId);
+        fitRafId = requestAnimationFrame(() => {
+          fitRafId = undefined;
+          if (fitAddon && term) {
+            fitAddon.fit();
+            resizeTerminal(workspaceId, term.rows, term.cols).catch(() => {});
+          }
+        });
       }
     });
     resizeObserver.observe(containerEl);
   });
 
   onDestroy(() => {
+    if (fitRafId !== undefined) cancelAnimationFrame(fitRafId);
     colorSchemeQuery?.removeEventListener("change", onColorSchemeChange);
     resizeObserver?.disconnect();
     term?.dispose();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,23 @@
 <script lang="ts">
   import "../app.css";
+  import { onMount } from "svelte";
 
   let { children } = $props();
+
+  // Suppress the benign "ResizeObserver loop" error globally.
+  // This fires when a ResizeObserver callback causes layout changes that produce
+  // new resize notifications that can't be delivered in the same frame. The browser
+  // re-queues them automatically — the warning is harmless by spec (ResizeObserver §3.3).
+  // Our VirtualScroller's measure→relayout cycle and xterm's fit() both trigger this.
+  onMount(() => {
+    function suppress(e: ErrorEvent) {
+      if (e.message?.startsWith("ResizeObserver loop")) {
+        e.stopImmediatePropagation();
+      }
+    }
+    window.addEventListener("error", suppress);
+    return () => window.removeEventListener("error", suppress);
+  });
 </script>
 
 {@render children()}


### PR DESCRIPTION
## Summary
- Debounce `fitAddon.fit()` in Terminal.svelte via `requestAnimationFrame` to prevent cascading resize notifications within the same observation cycle
- Add global error handler in root layout to suppress the benign "ResizeObserver loop completed with undelivered notifications" warning, which is inherent to VirtualScroller's measure→relayout cycle

## Test plan
- [ ] Resize the app window and verify no ResizeObserver warnings in the console
- [ ] Switch between workspace tabs and verify terminal still fits correctly
- [ ] Scroll through chat messages to confirm VirtualScroller still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)