### PR TITLE
fix: position toasts at top-right below title bar

### DIFF
--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -32,7 +32,7 @@
 <style>
   .toast-container {
     position: fixed;
-    bottom: 12px;
+    top: 52px;
     right: 12px;
     z-index: 9999;
     display: flex;


### PR DESCRIPTION
## Summary
- Moved toast container from bottom-right to top-right, positioned just below the title bar (`top: 52px`)

## Test plan
- [ ] Trigger a toast (e.g. error or success) and verify it appears at the top-right, below the title bar
- [ ] Verify toasts don't overlap the title bar or its controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)