### PR TITLE
fix: set TERM/locale env and sync PTY size for working terminal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3558,7 +3558,19 @@ pub fn open_terminal(
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let mut cmd = CommandBuilder::new(&shell);
+    cmd.arg("-l"); // Login shell: sources .zprofile/.zshrc for proper prompt & config
     cmd.cwd(&worktree_path);
+
+    // Terminal identity — critical for readline/zle to handle backspace, arrow keys, etc.
+    // Tauri is a GUI app so TERM is not in the parent environment.
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
+    cmd.env("SHELL", &shell);
+
+    // Locale — prevents garbled output for UTF-8 content
+    let lang = std::env::var("LANG").unwrap_or_else(|_| "en_US.UTF-8".to_string());
+    cmd.env("LANG", &lang);
+    cmd.env("LC_ALL", &lang);
 
     // Inject shell env for SSH, PATH, etc.
     if let Ok(sock) = std::env::var("SSH_AUTH_SOCK") {

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -108,11 +108,18 @@
       if (term) {
         term.write(new Uint8Array(data));
       }
-    }).catch((e) => {
-      if (term) {
-        term.writeln(`\r\n\x1b[31mFailed to open terminal: ${e}\x1b[0m`);
-      }
-    });
+    })
+      .then(() => {
+        // Sync PTY size with actual xterm dimensions (PTY defaults to 24x80)
+        if (term) {
+          resizeTerminal(workspaceId, term.rows, term.cols).catch(() => {});
+        }
+      })
+      .catch((e) => {
+        if (term) {
+          term.writeln(`\r\n\x1b[31mFailed to open terminal: ${e}\x1b[0m`);
+        }
+      });
   }
 
   onMount(() => {


### PR DESCRIPTION
## Summary
- Set `TERM=xterm-256color`, `COLORTERM`, `LANG`, `LC_ALL`, and `SHELL` env vars on the spawned PTY shell — Tauri is a GUI app with no terminal env, so backspace/arrow keys produced garbage
- Pass `-l` flag to spawn a login shell so `.zprofile`/`.zshrc` are sourced (prompt, aliases, PATH additions)
- Send initial `resizeTerminal()` after PTY opens so dimensions match the actual xterm viewport instead of the hardcoded 24×80 default

## Test plan
- [ ] Open terminal tab — verify shell prompt renders correctly
- [ ] Press backspace — should delete characters, not insert `^?`
- [ ] Press up/down arrows — should cycle through shell history
- [ ] Resize the window — terminal content should reflow correctly
- [ ] Switch workspaces and back — terminal should still be functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)