### PR TITLE
fix: move toast container from top-right to bottom-right

### DIFF
--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -32,7 +32,7 @@
 <style>
   .toast-container {
     position: fixed;
-    top: 52px;
+    bottom: 32px;
     right: 12px;
     z-index: 9999;
     display: flex;


### PR DESCRIPTION
## Summary
- Moves the toast notification container from `top: 52px` to `bottom: 32px`, positioning toasts in the bottom-right corner of the screen.

## Test plan
- [ ] Trigger a toast notification and verify it appears in the bottom-right corner
- [ ] Verify toast stacking still works correctly with multiple toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)