### PR TITLE
fix: raise search modal z-index above plan overlay and restrict search to work mode

### DIFF
--- a/src/lib/components/SearchModal.svelte
+++ b/src/lib/components/SearchModal.svelte
@@ -264,7 +264,7 @@
   .backdrop {
     position: fixed;
     inset: 0;
-    z-index: 200;
+    z-index: 1100;
     background: var(--overlay-bg);
     display: flex;
     align-items: flex-start;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -606,7 +606,7 @@ No need to mention in your report whether or not you used one of the fallback st
           if (selectedWsId) handleRemove(selectedWsId);
           break;
         case "f":
-          if (e.shiftKey && selectedWsId) {
+          if (e.shiftKey && selectedWsId && appMode === "work") {
             e.preventDefault();
             showSearchModal = true;
           }


### PR DESCRIPTION
## Summary
- Bumped SearchModal z-index from 200 to 1100 so it renders above the TaskPopover overlay (z-index 1000) when opened from the task editor's grep button
- Added `appMode === "work"` guard to the Cmd+Shift+F handler so the search shortcut is blocked in plan mode

## Test plan
- [ ] Open plan mode (Cmd+1), open a task popover, click the grep/search button — modal should appear above the popover
- [ ] In plan mode, press Cmd+Shift+F — nothing should happen
- [ ] In work mode, press Cmd+Shift+F — search modal opens as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)