### PR TITLE
fix: restyle kanban add-task and spawn buttons to use design tokens

### DIFF
--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -252,19 +252,19 @@
     justify-content: center;
     gap: 0.3rem;
     padding: 0.4rem;
-    background: transparent;
-    border: 1px dashed var(--border-light);
-    border-radius: 4px;
-    color: var(--text-dim);
+    background: var(--btn-subtle-bg);
+    border: none;
+    border-radius: 6px;
+    color: var(--text-secondary);
     font-family: inherit;
     font-size: 0.78rem;
     cursor: pointer;
+    transition: background 0.15s, color 0.15s;
   }
 
   .add-task-btn:hover {
-    color: var(--accent);
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 5%, transparent);
+    color: var(--text-primary);
+    background: var(--btn-subtle-hover);
   }
 
   .column-menu-btn {

--- a/src/lib/components/KanbanCard.svelte
+++ b/src/lib/components/KanbanCard.svelte
@@ -229,19 +229,21 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.3rem 0.55rem;
-    background: transparent;
-    border: 1px dashed var(--border-light);
-    border-radius: 4px;
-    color: var(--text-dim);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+    border-radius: 6px;
+    color: var(--accent);
     font-family: inherit;
     font-size: 0.7rem;
+    font-weight: 600;
     cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
   }
 
   .spawn-btn:hover {
     color: var(--accent);
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 5%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+    background: color-mix(in srgb, var(--accent) 20%, transparent);
   }
 
   .edit-btn {


### PR DESCRIPTION
## Summary
- Replaced dashed-border styling on kanban "Start" buttons with tinted accent style (matches `.go-btn` pattern)
- Replaced dashed-border styling on "+ New task" button with subtle glass background (matches `.cancel-btn` pattern)

## Test plan
- [ ] Verify "Start" button on TODO cards shows tinted accent background with solid border
- [ ] Verify "+ New task" button shows subtle glass background with no border
- [ ] Confirm hover states work correctly on both buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)