### PR TITLE
fix: sort repo list alphabetically by display name

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -541,6 +541,7 @@ pub fn list_repos(state: State<'_, Arc<Mutex<AppState>>>) -> Result<Vec<RepoDeta
     if needs_save {
         let _ = state.save_repos();
     }
+    details.sort_by(|a, b| a.display_name.to_lowercase().cmp(&b.display_name.to_lowercase()));
     Ok(details)
 }
 


### PR DESCRIPTION
## Summary
- Repo switcher dropdown in TitleBar had inconsistent ordering on each app launch because `list_repos` iterated over a `HashMap` with no guaranteed order
- Added case-insensitive alphabetical sort by `display_name` before returning results from the `list_repos` command

## Test plan
- [ ] Launch app with multiple repos added
- [ ] Verify repo switcher dropdown is alphabetically ordered
- [ ] Restart app and confirm order is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)