### PR TITLE
chore: simplify CLAUDE.md and DESIGN.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,181 +1,118 @@
 # Korlap — Claude Code Instructions
 
-## What this is
-Korlap is a Tauri v2 + Svelte 5 + Bun desktop app for orchestrating parallel Claude Code agents across git worktrees. Each workspace = one git worktree on an isolated branch. Full design spec is in `DESIGN.md`.
+Tauri v2 + Svelte 5 + Bun desktop app for orchestrating parallel Claude Code agents across git worktrees. Each workspace = one git worktree on an isolated branch. Full design spec in `DESIGN.md`.
 
 ---
 
-## Non-negotiable rules
-
-### Never break these, regardless of milestone or scope
+## Hard rules
 
 **Rust**
 - Every `#[tauri::command]` returns `Result<T, String>` — never panic, never unwrap in command handlers
-- All shared state goes through `Mutex<T>` inside Tauri's managed state — no globals, no lazy_static
-- PTY reader threads must handle EOF and errors gracefully and emit a terminal `agent-status` event on exit
-- Spawn `claude` with explicit env isolation — always inject `GH_TOKEN` from the repo's bound profile, never rely on ambient shell env
-- Never call `gh auth switch` globally — it mutates shared config and breaks parallel agents. Read token via `gh auth token --user <profile>` and inject per-process
-- All git operations that can fail (worktree add/remove, diff) must return descriptive errors, not generic ones
-- `portable-pty` PTY pair: always close the slave end in the parent process after spawning the child, or reads on the master will never see EOF
+- No `unwrap()` or `expect()` outside of tests
+- All shared state through `Mutex<T>` in Tauri managed state — no globals, no lazy_static
+- PTY reader threads handle EOF/errors gracefully, emit `agent-status` event on exit
+- `portable-pty`: always close slave end in parent after spawning child
+- Spawn `claude` with explicit env — inject `GH_TOKEN` per-process, never rely on ambient shell
+- Never call `gh auth switch` globally — use `gh auth token --user <profile>` and inject per-process
+- Git operations return descriptive errors, not generic ones
 
 **Frontend**
-- Never store PTY output in Svelte state — xterm.js owns its buffer, period
-- Never use a reactive `$state<Message[]>` array that gets replaced on each chunk — use `Map<id, Message>` and mutate individual entries
-- The message list uses keyed `{#each}` with `Map<string, Message>` — virtualization only when measured-height implementation is ready
-- xterm instances are never destroyed on workspace switch — use `display: none` / `block`, not mount/unmount
-- Tauri Channel API for PTY binary streams — never `listen()` + JSON for high-frequency byte data
-- All Tauri `invoke()` calls must be wrapped in try/catch with user-visible error handling — silent failures are not acceptable
+- PTY output never touches Svelte state — xterm.js owns its buffer
+- Messages use `SvelteMap<id, Message>`, mutated in place — never replace entire arrays
+- xterm instances use `display: none/block` on workspace switch — never mount/unmount
+- Tauri Channel API for binary streams — never `listen()` + JSON for high-frequency data
+- All `invoke()` calls wrapped in try/catch with user-visible error handling
 
-**Git**
-- Never operate on the main worktree's working directory — all writes go into the workspace's worktree path
-- All app data lives under Tauri's app data dir (`~/Library/Application Support/net.ghora.korlap/`) — zero files written to managed repos
-- Worktree paths: `<data_dir>/workspaces/<workspace-id>/`
+**Data**
+- All app data under `~/Library/Application Support/net.ghora.korlap/` — zero files in managed repos
+- Worktrees: `<data_dir>/workspaces/<workspace-id>/`
 - Messages: `<data_dir>/messages/<workspace-id>.json`
-- Workspace metadata persisted to `<data_dir>/workspaces.json`, session IDs to `<data_dir>/sessions.json`
+- Metadata: `<data_dir>/workspaces.json`, `<data_dir>/sessions.json`, `<data_dir>/repos.json`
+- Never operate on the main worktree's working directory
+
+**Commands**
+- Use `bun`, not `npm`, `npx`, or `yarn`
+- Type check: `bun run check`
+- Rust check: `cargo check` (never `cargo build` or `tauri build`)
 
 **General**
-- No `unwrap()` or `expect()` outside of tests
-- No `console.log` left in production paths — use a proper log level system (`tracing` in Rust, a thin wrapper in TS)
-- No hardcoded paths — always derive from repo root or app data dir via Tauri APIs
-- Every async operation that touches the filesystem or spawns a process must have a timeout
+- No `console.log` in production paths — `tracing` in Rust
+- No hardcoded paths — derive from repo root or Tauri app data dir
+- Async filesystem/process ops must have a timeout
 
 ---
 
 ## Architecture
 
-See `DESIGN.md` for full detail. Summary:
-
 ```
 src-tauri/src/
-  main.rs          — Tauri setup, managed state registration
-  workspace.rs     — worktree lifecycle (create, archive, restore)
-  agent.rs         — claude CLI spawn, PTY management, output streaming
-  git.rs           — diff, branch ops via git2
-  commands.rs      — all #[tauri::command] handlers
+  main.rs / lib.rs       — Tauri setup, state init, command registration
+  state.rs               — AppState, RepoInfo, WorkspaceInfo, WorkspaceStatus
+  mcp_api.rs             — MCP server (random port)
+  traffic.rs             — macOS traffic light positioning
+  commands/
+    mod.rs               — module exports
+    repo.rs              — add_repo, remove_repo, list_repos
+    workspace.rs         — create/remove/list/rename_branch
+    agent.rs             — send_message, stop_agent, generate_commit_message, suggest_replies
+    git.rs               — diff, commit, push, branch sync, base updates
+    github.rs            — gh profiles, PR status/merge, auth, repo listing/cloning
+    files.rs             — list/read/write/search/grep (workspace & repo level)
+    terminal.rs          — open/write/resize/close terminal (portable-pty)
+    scripts.rs           — run_script (zsh in worktree dir)
+    persistence.rs       — save/load messages, todos, images, repo settings
+    helpers.rs           — git auth, default branch detection, shell env
 
 src/
   lib/
     stores/
-      repos.svelte.ts        — Map<id, Repository>, activeRepoId
-      workspaces.svelte.ts   — Map<id, Workspace>, activeWorkspaceId, visibleWorkspaces derived
-      messages.svelte.ts     — Map<workspaceId, Map<msgId, Message>>
-    ipc.ts                   — typed invoke() wrappers + Channel setup
+      messages.svelte.ts — SvelteMap<wsId, SvelteMap<msgId, Message>>, sendingByWorkspace
+      toasts.svelte.ts   — toast notifications
+      theme.svelte.ts    — dark/light theme state
+    ipc.ts               — typed invoke() wrappers + event listeners
+    chat-utils.ts        — message rendering, mention parsing
+    markdown.ts          — markdown to HTML
+    actions.ts           — Svelte actions (external links, code copy)
+    pr-status.ts         — PR status cache
+    themes.ts            — color palette definitions
   components/
-    TitleBar.svelte
-    Sidebar.svelte
-    WorkspacePanel.svelte
-    Terminal.svelte          — xterm.js, never touches Svelte state
-    ChatPanel.svelte         — virtualized message list
-    DiffViewer.svelte
-    ScriptRunner.svelte
+    TitleBar.svelte      — repo tabs, plan/work mode, main branch sync
+    Sidebar.svelte       — workspace list with status dots
+    WorkspacePanel.svelte — tab bar (Chat/Diff/Terminal/Scripts/Files)
+    ChatPanel.svelte     — message list + input + agent streaming
+    Terminal.svelte      — xterm.js terminal
+    DiffViewer.svelte    — syntax-highlighted diffs
+    CodeEditor.svelte    — CodeMirror 6 editor
+    FileBrowser.svelte   — file tree navigation
+    SearchModal.svelte   — file + content search
+    KanbanBoard.svelte   — task board (draggable)
+    MentionInput.svelte  — rich input with @-file mentions
+    RepoSettings.svelte  — per-repo config (scripts, prompts, templates)
+    ... and more (see src/components/)
+  routes/
+    +page.svelte         — main app shell, state management, event listeners
 ```
 
 ---
 
-## State conventions
+## Key patterns
 
-```ts
-// Repos and workspaces: always Maps, never arrays
-const repos = $state(new Map<string, Repository>())
-const workspaces = $state(new Map<string, Workspace>())
-
-// Messages: nested Maps, mutate in place
-const messagesByWorkspace = $state(new Map<string, Map<string, Message>>())
-
-// Derived — never duplicated state
-const visibleWorkspaces = $derived(
-  activeRepoId
-    ? [...workspaces.values()].filter(w => w.repoId === activeRepoId)
-    : []
-)
-```
-
----
-
-## PTY streaming pipeline
-
-```
-claude process (slave PTY)
-  → Rust reader thread
-    → accumulate bytes, flush every 16ms max (~60fps)
-      → Tauri Channel (ArrayBuffer, not JSON)
-        → xterm.js terminal.write(data)
-```
-
-Nothing in this pipeline touches Svelte state. If you find yourself writing `messages.update(...)` in a PTY handler, stop — you're in the wrong path.
-
----
-
-## IPC surface (Tauri commands)
-
-All commands must:
-- Return `Result<T, String>` with human-readable error strings
-- Be idempotent where possible (e.g. `archive_workspace` on an already-archived workspace is a no-op, not an error)
-- Emit a corresponding Tauri event on state changes so the frontend stays in sync without polling
-
-```
-Repository:   add_repo, remove_repo, list_repos, set_active_repo, update_repo_profile, list_gh_profiles
-Workspace:    create_workspace, archive_workspace, restore_workspace, list_workspaces
-Agent:        spawn_agent, kill_agent, write_to_agent, resize_pty, open_pty_stream
-Git:          get_diff, get_branches
-Scripts:      run_script
-
-Events emitted:
-  agent-output   { workspace_id: string, data: ArrayBuffer }
-  agent-status   { workspace_id: string, status: WorkspaceStatus }
-  script-output  { workspace_id: string, data: string }
-```
+- **Agent output (structured chat):** `claude -p --output-format stream-json --verbose` → NDJSON parsed in Rust → streamed to frontend via Tauri Channel as `AgentEvent`s → rendered in ChatPanel.
+- **Terminal (raw PTY):** `portable-pty` → Rust reader thread → Tauri Channel (binary) → `xterm.js`. Nothing in this pipeline touches Svelte state.
+- **Persistence:** Messages debounced at 500ms, fire-and-forget. Workspace/repo metadata saved on mutation.
+- **GH auth:** Token read via `gh auth token --user <profile>`, injected as env var per spawned process. Never mutate global gh config.
 
 ---
 
 ## Visual identity
 
-- Background: `#13110e` — warm dark, amber-tinted, not cold gray
-- Single accent: `#c8a97e` — used for running state, active branch, interactive focus
-- Typeface: Space Grotesk (already imported via Google Fonts)
-- No app name in the title bar
-- Status colors: running = `#c8a97e` (pulsing), waiting = `#7e9e6b`, archived = `#2a2420`
-- No avatar, no xterm.js — agent output is structured chat via `--output-format stream-json`
-
-Full token reference and component mockup in `DESIGN.md`.
+See `design.md` for color tokens. Colors are defined via a dynamic theme system in `lib/themes.ts` — never hardcode hex values, always use CSS custom properties / theme tokens. Typeface: Space Grotesk.
 
 ---
 
-## Milestones — build in order, do not skip ahead
-
-### M1 — Core plumbing ✅
-- `add_repo`: folder picker, validate git repo, detect default branch, persist to repos.json
-- `create_workspace`: random name, `git worktree add -b conductor/<name>`, persist to .korlap/workspaces.json
-- `send_message`: spawn `claude -p --output-format stream-json --verbose`, parse NDJSON, stream via Tauri Channel
-- `archive_workspace`: kill agent if running, `git worktree remove --force`, mark archived
-- `list_workspaces`: restore state from workspaces.json on app start
-- Session resume via `--resume` flag for multi-turn conversations
-
-### M2 — Real UI ✅
-- Sidebar workspace list with status dots (pulsing amber / olive / dim)
-- Custom title bar: traffic lights positioning, repo tabs, breadcrumb (branch › base), window dragging
-- Tab bar (Chat, Diff, Terminal, Scripts) with RUNNING/WAITING status badge
-- Workspace switching via `display:none` — no teardown, preserves scroll
-- Components: TitleBar, Sidebar, ChatPanel
-
-### M3 — Diff + Scripts
-- Diff tab: `git diff <base>..<branch>` rendered with syntax highlighting (additions green, deletions red, warm palette)
-- Scripts tab: run arbitrary shell commands in worktree dir, stream output
-- gh profile pills on repo tabs
-
-### M4 — Polish
-- Workspace state survives app restart (workspaces.json fully round-trips)
-- Archive/restore UI
-- Keyboard shortcuts: ⌘N new workspace, ⌘W archive, ⌘1–9 switch workspace
-- Error states: repo not found, git op failed, agent crashed — all surface to UI
-- System prompt injection (configurable per-workspace instructions)
-
----
-
-## What not to build (ever, unless explicitly instructed)
-- PR creation via GitHub API
+## What not to build (unless explicitly instructed)
 - Codex support
 - Checkpoint/restore of Claude conversation history
 - MCP config UI
-- Multi-repo open simultaneously (one active repo at a time)
+- Multi-repo open simultaneously
 - Windows support

--- a/design.md
+++ b/design.md
@@ -1,4 +1,5 @@
-# Conductor Clone — Design Doc
+# Korlap — Design Doc
+
 ## Stack: Tauri v2 + Svelte 5 + Bun
 
 ---
@@ -7,29 +8,9 @@
 
 **Name:** Korlap (from Indonesian "koordinator lapangan" — field coordinator, the person who orchestrates parallel operations on the ground)
 
-**Design direction:** Warm dark. All blacks tinted amber, not cold gray. Single accent color: `#c8a97e` (muted gold). Nothing else competes with it.
+**Design direction:** Warm dark. All blacks tinted amber, not cold gray. Multiple theme palettes defined in `src/lib/themes.ts` — never hardcode hex values, always use CSS custom properties (e.g. `var(--bg-base)`, `var(--accent)`).
 
-**Color hierarchy** (darkest → lightest):
-| Token | Hex | Usage |
-|-------|-----|-------|
-| `bg-sidebar` | `#0f0d0a` | Sidebar, deepest layer |
-| `bg-base` | `#12110e` | Main panel background, body |
-| `bg-titlebar` | `#1a1611` | Title bar, tab bar |
-| `bg-card` | `#1a1814` | Assistant message cards, input fields |
-| `bg-hover` | `#1e1b17` | Hover states |
-| `bg-active` | `#2a2520` | Selected items, user bubbles, active tab |
-| `border` | `#1e1b18` | Primary borders (soft, low contrast) |
-| `border-light` | `#3a3530` | Active item borders, button borders |
-| `text-muted` | `#4a4540` | Placeholders, separators |
-| `text-dim` | `#6a6050` | Labels, breadcrumb base, secondary text |
-| `text-secondary` | `#8a7e6a` | Tool tags, inactive tabs, button text |
-| `text-primary` | `#d4c5a9` | Body text, input text |
-| `text-bright` | `#e8dcc8` | Headings, active items, user message text |
-| `accent` | `#c8a97e` | Running state, active branch, focus ring |
-| `status-ok` | `#7e9e6b` | Waiting/ready state |
-| `diff-add` | `#7e9e6b` / bg `#1a2a1a` | Diff additions |
-| `diff-del` | `#c87e7e` / bg `#2a1a1a` | Diff deletions |
-| `error` | `#e88` / bg `#3a1a1a` | Error states |
+**Token names** (used across all palettes): `bg-sidebar`, `bg-base`, `bg-titlebar`, `bg-card`, `bg-hover`, `bg-active`, `border`, `border-light`, `text-muted`, `text-dim`, `text-secondary`, `text-primary`, `text-bright`, `accent`, `status-ok`, `diff-add`, `diff-add-bg`, `diff-del`, `diff-del-bg`, `error`, `error-bg`.
 
 **Typeface:** Space Grotesk. Geometric, purposeful, slightly idiosyncratic. Not Inter.
 
@@ -45,9 +26,9 @@ Repositories are first-class entities. Workspaces are children of a repository. 
 
 Core primitives:
 - `git worktree` for workspace isolation
-- `claude` CLI as agent subprocess with PTY
-- `gh auth switch` integrated — called transparently before any `gh` op on a repo
-- Per-workspace state + diff viewing
+- `claude` CLI as agent subprocess — structured chat via `--output-format stream-json`
+- `gh auth token --user <profile>` for per-process token injection (never `gh auth switch`)
+- Per-workspace state, diff viewing, terminal, file browsing, and task management
 
 ---
 
@@ -59,504 +40,64 @@ Core primitives:
 | UI | Svelte 5 | Runes-based reactivity is genuinely good; minimal overhead |
 | Runtime | Bun | Fast installs, built-in TS, test runner |
 | Styling | Tailwind v4 | Zero config, good DX |
-| Terminal emulator | xterm.js | De-facto standard; works well in Tauri WebView |
+| Terminal | xterm.js | De-facto standard; works well in Tauri WebView |
+| Code editor | CodeMirror 6 | Multi-language syntax highlighting, used for file editing |
 
 ---
 
-## Project Structure
+## Performance Principles
 
-```
-conductor/
-├── src-tauri/
-│   ├── src/
-│   │   ├── main.rs
-│   │   ├── workspace.rs     # worktree create/archive/restore
-│   │   ├── agent.rs         # claude CLI spawn + PTY management
-│   │   ├── git.rs           # diff, branch, push ops via git2
-│   │   └── commands.rs      # Tauri #[command] handlers (IPC bridge)
-│   └── Cargo.toml
-├── src/
-│   ├── lib/
-│   │   ├── stores/
-│   │   │   ├── workspaces.svelte.ts   # $state workspace list
-│   │   │   └── agent.svelte.ts        # per-workspace agent state
-│   │   └── ipc.ts                     # typed wrappers around invoke()
-│   ├── components/
-│   │   ├── Sidebar.svelte             # workspace list
-│   │   ├── WorkspacePanel.svelte      # main content area
-│   │   ├── Terminal.svelte            # xterm.js PTY passthrough
-│   │   ├── DiffViewer.svelte          # git diff renderer
-│   │   └── ScriptRunner.svelte
-│   ├── app.svelte
-│   └── app.css
-├── package.json
-└── bunfig.toml
-```
-
----
-
-## Rust Backend Design
-
-### Core Data Model
-
-```rust
-#[derive(Serialize, Deserialize, Clone)]
-pub struct Repository {
-    pub id: String,           // uuid
-    pub path: PathBuf,        // local clone path — unique key, one profile per path
-    pub name: String,         // derived from git remote or dirname
-    pub gh_profile: String,   // gh auth switch profile name (e.g. "personal", "work-acme")
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub struct Workspace {
-    pub id: String,
-    pub repo_id: String,      // FK -> Repository
-    pub name: String,
-    pub branch: String,
-    pub worktree_path: PathBuf,
-    pub status: WorkspaceStatus,
-    pub created_at: i64,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(tag = "type")]
-pub enum WorkspaceStatus {
-    Idle,
-    Running { pid: u32 },
-    Waiting,    // agent paused at permission prompt
-    Done,
-    Archived,
-}
-```
-
-### State (Tauri Managed State)
-
-```rust
-pub struct AppState {
-    pub repos: Mutex<HashMap<String, Repository>>,
-    pub workspaces: Mutex<HashMap<String, Workspace>>,
-    pub agents: Mutex<HashMap<String, AgentHandle>>,
-    pub active_repo_id: Mutex<Option<String>>,
-}
-
-pub struct AgentHandle {
-    pub pty_master: Box<dyn MasterPty>,
-    pub writer: Box<dyn Write + Send>,
-    pub pid: u32,
-}
-```
-
-### `gh` Profile Switching
-
-`gh auth switch` is a process-level operation — it mutates `~/.config/gh/hosts.yml`. Since agents run concurrently across repos with potentially different profiles, we **never call `gh auth switch` globally**. Instead, we inject `GH_TOKEN` per-process by reading the token for the bound profile at spawn time.
-
-```rust
-fn gh_token_for_profile(profile: &str) -> Result<String> {
-    // `gh auth token --hostname github.com --user <profile>`
-    let out = Command::new("gh")
-        .args(["auth", "token", "--user", profile])
-        .output()?;
-    Ok(String::from_utf8(out.stdout)?.trim().to_string())
-}
-
-fn spawn_agent(ws: &Workspace, repo: &Repository, app: &AppHandle) -> Result<AgentHandle> {
-    let token = gh_token_for_profile(&repo.gh_profile)?;
-
-    let mut cmd = CommandBuilder::new("claude");
-    cmd.cwd(&ws.worktree_path);
-    cmd.env("GH_TOKEN", token);
-    cmd.env("GITHUB_TOKEN", token); // some tools check this instead
-
-    // ... rest of PTY spawn
-}
-```
-
-This is safe for parallel agents across different repos — no global state mutation, each process gets its own env.
-
-### Tauri Commands (IPC surface)
-
-```rust
-// Repository management
-#[tauri::command] add_repo(path, gh_profile) -> Result<Repository>
-#[tauri::command] remove_repo(repo_id) -> Result<()>
-#[tauri::command] list_repos() -> Result<Vec<Repository>>
-#[tauri::command] set_active_repo(repo_id) -> Result<()>
-#[tauri::command] list_gh_profiles() -> Result<Vec<String>>   // shells out to `gh auth status`
-#[tauri::command] update_repo_profile(repo_id, gh_profile) -> Result<()>
-
-// Workspace management (all scoped to a repo)
-#[tauri::command] create_workspace(repo_id, name, base_branch) -> Result<Workspace>
-#[tauri::command] archive_workspace(id) -> Result<()>
-#[tauri::command] restore_workspace(id) -> Result<Workspace>
-#[tauri::command] list_workspaces(repo_id) -> Result<Vec<Workspace>>
-
-// Agent
-#[tauri::command] spawn_agent(workspace_id) -> Result<u32>
-#[tauri::command] kill_agent(workspace_id) -> Result<()>
-#[tauri::command] write_to_agent(workspace_id, data: Vec<u8>) -> Result<()>
-#[tauri::command] resize_pty(workspace_id, rows: u16, cols: u16) -> Result<()>
-
-// Git
-#[tauri::command] get_diff(workspace_id) -> Result<String>
-#[tauri::command] get_branches(repo_id) -> Result<Vec<String>>
-
-// Scripts
-#[tauri::command] run_script(workspace_id, script: String) -> Result<()>
-
-// Events emitted TO frontend
-// "agent-output"  { workspace_id, data: Vec<u8> }
-// "agent-status"  { workspace_id, status: WorkspaceStatus }
-```
-
-### Worktree Lifecycle
-
-```rust
-// create
-fn create_workspace(name: &str, base: &str, repo: &Path) -> Result<Workspace> {
-    let id = Uuid::new_v4().to_string();
-    let branch = format!("conductor/{name}");
-    let path = repo.join(".conductor/worktrees").join(&id);
-
-    Command::new("git")
-        .args(["worktree", "add", "-b", &branch, path.to_str().unwrap(), base])
-        .current_dir(repo)
-        .output()?;
-
-    Ok(Workspace { id, branch, worktree_path: path, status: Idle, .. })
-}
-
-// archive: kill agent + remove worktree from fs (branch survives)
-fn archive_workspace(ws: &Workspace) -> Result<()> {
-    Command::new("git")
-        .args(["worktree", "remove", "--force", ws.worktree_path.to_str().unwrap()])
-        .output()?;
-    Ok(())
-}
-
-// restore: re-add worktree on existing branch
-fn restore_workspace(ws: &Workspace, repo: &Path) -> Result<()> {
-    Command::new("git")
-        .args(["worktree", "add", ws.worktree_path.to_str().unwrap(), &ws.branch])
-        .current_dir(repo)
-        .output()?;
-    Ok(())
-}
-```
-
-### PTY / Agent Spawning
-
-Use `portable-pty` crate. Key flow:
-
-```rust
-fn spawn_agent(ws: &Workspace, app_handle: &AppHandle) -> Result<AgentHandle> {
-    let pty_system = native_pty_system();
-    let pair = pty_system.openpty(PtySize { rows: 24, cols: 80, .. })?;
-
-    let cmd = CommandBuilder::new("claude");
-    let _child = pair.slave.spawn_command(cmd)?;
-
-    let master = pair.master;
-    let mut reader = master.try_clone_reader()?;
-    let workspace_id = ws.id.clone();
-    let handle = app_handle.clone();
-
-    // stream PTY output -> frontend via Tauri event
-    thread::spawn(move || {
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) | Err(_) => break,
-                Ok(n) => {
-                    handle.emit("agent-output", AgentOutput {
-                        workspace_id: workspace_id.clone(),
-                        data: buf[..n].to_vec(),
-                    }).ok();
-                }
-            }
-        }
-    });
-
-    Ok(AgentHandle { pty_master: master, writer: pair.master.take_writer()?, .. })
-}
-```
-
----
-
-## Frontend Design
-
-### Performance Rules (non-negotiable)
-
-1. **Chat messages use `Map<string, Map<string, Message>>`.** Updating one message = one reactive cell, not the whole list. Never use arrays for collections that update frequently.
+1. **Chat messages use `SvelteMap<id, SvelteMap<id, Message>>`.** Updating one message = one reactive cell, not the whole list. Never use arrays for collections that update frequently.
 2. **Keyed `{#each}` blocks everywhere.** Svelte diffs by key — without keys it re-renders the entire list.
 3. **Persistence is debounced.** Messages saved to disk every 500ms, not on every event. Fire-and-forget — never block the UI thread.
-4. **Active workspace switch is O(1).** Just toggle `display:none`. No data fetching, no re-initialization. Each workspace's chat panel stays alive in the DOM.
-5. **All app data in Tauri's app data dir.** Zero writes to the managed repo. No `.korlap/` folder, no gitignore entries.
+4. **Workspace switch is O(1).** Toggle `display:none` on panels. No data fetching, no re-initialization. Each workspace's xterm/chat stays alive in the DOM.
+5. **All app data in Tauri's app data dir.** Zero writes to the managed repo.
+6. **PTY binary streams via Tauri Channel API.** No JSON serialization on the hot path.
 
 ---
 
-### State Shape
+## App Layout
 
-```ts
-// stores/repos.svelte.ts
-export const repos = $state(new Map<string, Repository>());
-export const activeRepoId = $state<string | null>(null);
-export const activeRepo = $derived(
-    activeRepoId ? repos.get(activeRepoId) ?? null : null
-);
+Two top-level modes toggled via title bar (⌘1 / ⌘2):
 
-// stores/workspaces.svelte.ts
-// Flat map of all workspaces across all repos.
-// UI filters by activeRepoId — no separate per-repo lists to keep in sync.
-export const workspaces = $state(new Map<string, Workspace>());
-export const activeWorkspaceId = $state<string | null>(null);
-
-export const visibleWorkspaces = $derived(
-    activeRepoId
-        ? [...workspaces.values()].filter(w => w.repoId === activeRepoId)
-        : []
-);
-
-// The single biggest performance decision: Map, not array.
-// Updating one message = one reactive cell changes, not the whole list.
-type MessageChunk = { type: "text"; content: string } | { type: "tool"; name: string; input: string };
-
-interface Message {
-    id: string;
-    role: "user" | "assistant";
-    chunks: MessageChunk[];
-    done: boolean;
-}
-
-// stores/messages.svelte.ts
-
-// stores/messages.svelte.ts
-// Keyed by workspaceId -> message list (also a Map for O(1) tail updates)
-export const messagesByWorkspace = $state(new Map<string, Map<string, Message>>());
-
-// Append a chunk to the last message — only that message's reactive cell fires
-export function appendChunk(workspaceId: string, messageId: string, chunk: MessageChunk) {
-    const msgs = messagesByWorkspace.get(workspaceId)!;
-    const msg = msgs.get(messageId)!;
-    msg.chunks.push(chunk);  // fine: Svelte 5 tracks array mutations at the property level
-}
+**Plan mode** — kanban board for task management:
+```
+┌──────────────────────────────────────────────────────────┐
+│  repo ⌘E  ⚙    [Plan ⌘1] [Work ⌘2]                     │
+├──────────────────────────────────────────────────────────┤
+│  TODO        IN PROGRESS      REVIEW        DONE        │
+│ ┌────────┐  ┌────────────┐  ┌──────────┐  ┌──────────┐ │
+│ │        │  │ task title  │  │          │  │ done task │ │
+│ │        │  │ description │  │          │  │ +N -N     │ │
+│ │        │  │ branch +N-N │  │          │  │           │ │
+│ └────────┘  └────────────┘  └──────────┘  └──────────┘ │
+│                    [+ New task]                          │
+└──────────────────────────────────────────────────────────┘
 ```
 
-### Rust: PTY Batching
-
-The Rust reader thread accumulates bytes and flushes on a timer, not per read. This caps IPC event rate regardless of how fast the agent writes.
-
-```rust
-fn stream_pty_output(
-    mut reader: Box<dyn Read + Send>,
-    workspace_id: String,
-    app: AppHandle,
-) {
-    let mut buf = [0u8; 8192];
-    let mut accumulator: Vec<u8> = Vec::with_capacity(16384);
-    let mut last_flush = Instant::now();
-    const FLUSH_INTERVAL: Duration = Duration::from_millis(16); // ~60fps
-
-    loop {
-        match reader.read(&mut buf) {
-            Ok(0) | Err(_) => break,
-            Ok(n) => {
-                accumulator.extend_from_slice(&buf[..n]);
-                if last_flush.elapsed() >= FLUSH_INTERVAL {
-                    app.emit("agent-output", AgentOutput {
-                        workspace_id: workspace_id.clone(),
-                        data: std::mem::take(&mut accumulator),
-                    }).ok();
-                    last_flush = Instant::now();
-                }
-            }
-        }
-    }
-    // flush remainder
-    if !accumulator.is_empty() {
-        app.emit("agent-output", AgentOutput { workspace_id, data: accumulator }).ok();
-    }
-}
+**Work mode** — workspace chat, diff, files, terminal:
+```
+┌──────────────────────────────────────────────────────────┐
+│  repo ⌘E  ⚙    [Plan ⌘1] [Work ⌘2]   branch › main     │
+├──────────┬───────────────────────────────────────────────┤
+│          │  Chat  Diff  Files  Terminal  ▶Run   🔍 PR    │
+│ ● auth   │  ┌─────────────────────────────────────────┐  │
+│   fix    │  │                                         │  │
+│          │  │   active tab content                     │  │
+│ ○ ui-    │  │                                         │  │
+│   rework │  │                                         │  │
+│          │  └─────────────────────────────────────────┘  │
+└──────────┴───────────────────────────────────────────────┘
 ```
 
-### IPC: Binary Transfer
-
-`Vec<u8>` serialized as a JSON number array is wasteful. Use Tauri's `ArrayBuffer` channel instead:
-
-```ts
-// Frontend receives PTY data as ArrayBuffer, not number[]
-// In tauri.conf.json, use invoke channels for high-frequency binary data
-
-import { Channel } from "@tauri-apps/api/core";
-
-export function openPtyChannel(workspaceId: string, onData: (data: Uint8Array) => void) {
-    const ch = new Channel<ArrayBuffer>();
-    ch.onmessage = buf => onData(new Uint8Array(buf));
-    invoke("open_pty_stream", { workspaceId, channel: ch });
-    return ch;
-}
-```
-
-This bypasses JSON serialization entirely for the hot path.
-
-### Terminal Component
-
-xterm.js is a black box. We never read from it, only write to it. Its internal canvas renderer handles everything.
-
-```svelte
-<!-- Terminal.svelte -->
-<script lang="ts">
-  import { onMount } from "svelte";
-  import { Terminal } from "@xterm/xterm";
-  import { FitAddon } from "@xterm/addon-fit";
-  import { openPtyChannel } from "$lib/ipc";
-
-  let { workspaceId }: { workspaceId: string } = $props();
-  let el: HTMLDivElement;
-
-  onMount(() => {
-    const term = new Terminal({
-        scrollback: 5000,  // cap scrollback, don't let it grow unbounded
-        theme: { background: "#0d0d0d" },
-    });
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.open(el);
-    fit.fit();
-
-    // resize: propagate to PTY so apps (vim, etc.) behave correctly
-    const ro = new ResizeObserver(() => {
-        fit.fit();
-        invoke("resize_pty", { workspaceId, rows: term.rows, cols: term.cols });
-    });
-    ro.observe(el);
-
-    term.onData(data =>
-        invoke("write_to_agent", { workspaceId, data: new TextEncoder().encode(data) })
-    );
-
-    const ch = openPtyChannel(workspaceId, data => term.write(data));
-
-    return () => { ch.close(); ro.disconnect(); term.dispose(); };
-  });
-</script>
-
-<div bind:this={el} class="h-full w-full" />
-```
-
-### Message List
-
-**No fixed-height virtualization for chat.** Chat messages are variable-height (short replies, code blocks, tool use lists). A fixed `itemHeight` VirtualList breaks layout — `position: relative` + `transform: translateY` kills flexbox alignment needed for user/assistant message positioning.
-
-The real performance wins for the message list are:
-
-1. **`Map<string, Message>` not arrays** — updating one message doesn't trigger a full list re-render. Already implemented in `stores/messages.svelte.ts`.
-2. **Keyed `{#each}` blocks** — Svelte only re-renders changed messages via `(msg.id)` keys.
-3. **Debounced persistence** — messages saved to disk at most every 500ms, not per-message.
-
-If message count becomes a bottleneck (hundreds per workspace), implement **measured-height virtualization** — render items, measure with ResizeObserver, cache heights in a Map, then calculate visible window. Not the naive fixed-height approach.
-
-### Workspace Switching
-
-xterm instances are **never destroyed** when switching workspaces — only detached from the DOM. This preserves scrollback and avoids re-initialization cost.
-
-```svelte
-<!-- WorkspacePanel.svelte -->
-<script lang="ts">
-  import { activeId } from "$lib/stores/workspaces.svelte";
-
-  let { workspaceIds }: { workspaceIds: string[] } = $props();
-</script>
-
-<!-- All terminals rendered, only active one visible -->
-{#each workspaceIds as id (id)}
-  <div class={id === activeId ? "block" : "hidden"}>
-    <Terminal workspaceId={id} />
-  </div>
-{/each}
-```
-
-`hidden` = `display: none`. The xterm canvas stays alive, no teardown/reinit on switch. Cost of switching is one class toggle.
-
-### App Layout
-
-```
-┌──────────────────────────────────────────────────────┐
-│  ◆ Conductor   my-app   [+ New Workspace]    ⚙       │
-├──────────┬───────────────────────────────────────────┤
-│          │  feat/auth-refactor          [⚡Running]  │
-│ ● auth   │  ┌─────────────────────────────────────┐  │
-│   fix    │  │  [Chat] [Diff] [Terminal] [Scripts] │  │
-│          │  ├─────────────────────────────────────┤  │
-│ ○ ui-    │  │                                     │  │
-│   rework │  │   xterm.js PTY panel here           │  │
-│          │  │                                     │  │
-│ ⊘ old    │  │                                     │  │
-│   feat   │  │                                     │  │
-│          │  └─────────────────────────────────────┘  │
-└──────────┴───────────────────────────────────────────┘
-```
-
-Sidebar: workspace list with status indicator (running / waiting / idle / archived).
-Main panel: tab strip per workspace (Chat, Diff, Terminal, Scripts).
+Sidebar: workspace list with status dots (pulsing amber = running, olive = waiting).
+Work mode tabs: Chat, Diff, Files, Terminal, Run. Actions: Review, Push & create PR.
 
 ---
 
-## Key Dependencies
-
-### Rust (Cargo.toml)
-```toml
-tauri = { version = "2", features = ["shell-open"] }
-portable-pty = "0.8"
-git2 = "0.19"
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
-uuid = { version = "1", features = ["v4"] }
-```
-
-### Frontend (package.json)
-```json
-{
-  "@tauri-apps/api": "^2",
-  "@tauri-apps/plugin-shell": "^2",
-  "@xterm/xterm": "^5",
-  "@xterm/addon-fit": "^0.10",
-  "svelte": "^5",
-  "tailwindcss": "^4",
-  "typescript": "^5"
-}
-```
-
----
-
-## MVP Milestones
-
-### M1 — Plumbing (no real UI)
-- Open a repo, persist path
-- Create / archive / restore worktrees
-- Spawn `claude` in a worktree via PTY
-- Stream PTY output to a dumb `<pre>` tag
-
-### M2 — Real UI
-- Sidebar workspace list with status
-- xterm.js terminal per workspace (input + output)
-- Tab strip (Chat + Terminal to start)
-
-### M3 — Diff + Scripts
-- Diff tab: `git diff main..<branch>` rendered with syntax highlighting
-- Scripts tab: run arbitrary shell commands, stream output
-
-### M4 — Polish
-- Workspace state persistence across restarts (workspaces.json)
-- Archive/restore UI
-- Keyboard shortcuts
-
----
-
-## Explicitly Out of Scope (v0)
-
-- PR creation
+## What not to build (unless explicitly instructed)
+- Codex support
+- Checkpoint/restore of Claude conversation history
 - MCP config UI
-- Checkpoints / conversation restore
-- Multi-repo support
-- Windows support (PTY story is painful)
+- Multi-repo open simultaneously
+- Windows support


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Rewrote to match actual codebase — updated architecture tree, removed stale milestones/IPC surface, added explicit `bun` command rules, replaced hardcoded color values with theme system reference
- **DESIGN.md**: Trimmed from 560 → ~120 lines — removed all stale code examples (wrong APIs, phantom deps like `git2`), replaced hex color table with theme token names, updated app layout to show Plan/Work modes

Both files were heavily outdated and actively misleading agents (wrong file structure, wrong command names, `npx` instead of `bun`, hardcoded colors instead of theme tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)