### PR TITLE
feat: add TodoWrite task progress UI with visual block rendering

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -182,6 +182,12 @@ fn extract_input_preview(
                 return Some(questions.to_string());
             }
         }
+        // TodoWrite: pass the full todos array for rich progress rendering
+        if name == "TodoWrite" {
+            if let Some(todos) = input.get("todos") {
+                return Some(todos.to_string());
+            }
+        }
         if let Some(fp) = input.get("file_path").and_then(|f| f.as_str()) {
             Some(strip(fp))
         } else if let Some(cmd) = input.get("command").and_then(|c| c.as_str()) {

--- a/src/lib/chat-utils.ts
+++ b/src/lib/chat-utils.ts
@@ -1,7 +1,7 @@
 import type { Message, MessageChunk, MessageMention } from "$lib/stores/messages.svelte.js";
 import {
   FileText, Pencil, FilePlus, Terminal, FolderSearch, TextSearch,
-  Bot, Globe, Zap, Settings, MessageCircleQuestion,
+  Bot, Globe, Zap, Settings, MessageCircleQuestion, ListChecks,
 } from "lucide-svelte";
 
 // ── Tool icon mapping ────────────────────────────────────────────────
@@ -19,6 +19,7 @@ export const toolIcons: Record<string, typeof Settings> = {
   Skill: Zap,
   ToolSearch: Settings,
   AskUserQuestion: MessageCircleQuestion,
+  TodoWrite: ListChecks,
 };
 
 // ── Shared types ─────────────────────────────────────────────────────
@@ -90,6 +91,7 @@ export type VisualBlock =
   | { kind: "thinking"; chunk: MessageChunk & { type: "thinking" }; key: string }
   | { kind: "text"; chunk: MessageChunk & { type: "text" }; msgId: string; key: string }
   | { kind: "special-tool"; chunk: MessageChunk & { type: "tool" }; msgId: string; ci: number; key: string }
+  | { kind: "todo-list"; chunk: MessageChunk & { type: "tool" }; msgId: string; ci: number; isLatest: boolean; key: string }
   | { kind: "tool-group"; tools: ToolEntry[]; key: string };
 
 export function buildVisualBlocks(msgs: Message[]): VisualBlock[] {
@@ -134,17 +136,31 @@ export function buildVisualBlocks(msgs: Message[]): VisualBlock[] {
         flushTools();
         blocks.push({ kind: "text", chunk, msgId: msg.id, key: `text:${msg.id}` });
       } else if (chunk.type === "tool") {
-        const isSpecial = chunk.name === "AskUserQuestion" ||
-                          (chunk.oldString != null && chunk.newString != null);
-        if (isSpecial) {
+        if (chunk.name === "TodoWrite") {
           flushTools();
-          blocks.push({ kind: "special-tool", chunk, msgId: msg.id, ci, key: `st:${msg.id}:${ci}` });
+          blocks.push({ kind: "todo-list", chunk, msgId: msg.id, ci, isLatest: false, key: `todo:${msg.id}:${ci}` });
         } else {
-          pendingTools.push({ chunk, msgId: msg.id, ci });
+          const isSpecial = chunk.name === "AskUserQuestion" ||
+                            (chunk.oldString != null && chunk.newString != null);
+          if (isSpecial) {
+            flushTools();
+            blocks.push({ kind: "special-tool", chunk, msgId: msg.id, ci, key: `st:${msg.id}:${ci}` });
+          } else {
+            pendingTools.push({ chunk, msgId: msg.id, ci });
+          }
         }
       }
     }
   }
   flushTools();
+
+  // Mark the last TodoWrite block as the latest (it reflects current state)
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    if (blocks[i].kind === "todo-list") {
+      (blocks[i] as Extract<VisualBlock, { kind: "todo-list" }>).isLatest = true;
+      break;
+    }
+  }
+
   return blocks;
 }

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -9,6 +9,7 @@
   import VirtualScroller from "./VirtualScroller.svelte";
   import AskUserQuestion from "./chat/AskUserQuestion.svelte";
   import EditDiffBlock from "./chat/EditDiffBlock.svelte";
+  import TodoListBlock from "./chat/TodoListBlock.svelte";
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import {
     toolIcons,
@@ -115,6 +116,9 @@
 
   // Parent-owned state for EditDiffBlock — survives VirtualScroller recycling
   const collapsedDiffs = new SvelteSet<string>();
+
+  // Parent-owned state for TodoListBlock — survives VirtualScroller recycling
+  const expandedTodoBlocks = new SvelteSet<string>();
 
   // Parent-owned state for AskUserQuestion — survives VirtualScroller recycling
   const askSelectedOptions = new SvelteMap<string, SvelteSet<string>>();
@@ -494,6 +498,15 @@
                   chunk={block.chunk}
                   collapsed={collapsedDiffs.has(diffKey)}
                   onToggle={() => { collapsedDiffs.has(diffKey) ? collapsedDiffs.delete(diffKey) : collapsedDiffs.add(diffKey); }}
+                />
+              </div>
+            {:else if block.kind === "todo-list"}
+              <div class="assistant-msg">
+                <TodoListBlock
+                  chunk={block.chunk}
+                  isLatest={block.isLatest}
+                  collapsed={block.isLatest ? false : !expandedTodoBlocks.has(block.key)}
+                  onToggle={() => { expandedTodoBlocks.has(block.key) ? expandedTodoBlocks.delete(block.key) : expandedTodoBlocks.add(block.key); }}
                 />
               </div>
             {/if}

--- a/src/lib/components/chat/TodoListBlock.svelte
+++ b/src/lib/components/chat/TodoListBlock.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+  import { ListChecks, CheckCircle2, Circle, Loader } from "lucide-svelte";
+  import type { MessageChunk } from "$lib/stores/messages.svelte";
+
+  interface TodoItem {
+    id?: string;
+    content: string;
+    status: "pending" | "in_progress" | "completed";
+    priority?: "high" | "medium" | "low";
+  }
+
+  interface Props {
+    chunk: MessageChunk & { type: "tool" };
+    isLatest: boolean;
+    collapsed: boolean;
+    onToggle: () => void;
+  }
+
+  let { chunk, isLatest, collapsed, onToggle }: Props = $props();
+
+  let todos = $derived((() => {
+    try {
+      const parsed = JSON.parse(chunk.input);
+      return Array.isArray(parsed) ? parsed as TodoItem[] : [];
+    } catch {
+      return null;
+    }
+  })());
+
+  let completedCount = $derived(todos ? todos.filter(t => t.status === "completed").length : 0);
+  let inProgressCount = $derived(todos ? todos.filter(t => t.status === "in_progress").length : 0);
+  let totalCount = $derived(todos ? todos.length : 0);
+</script>
+
+<div class="todo-block">
+  <button class="todo-header" onclick={onToggle}>
+    <span class="todo-chevron" class:collapsed>▾</span>
+    <span class="todo-icon"><ListChecks size={13} strokeWidth={2} /></span>
+    <span class="todo-label">Task progress</span>
+    {#if todos && totalCount > 0}
+      <span class="todo-count">{completedCount}/{totalCount} completed</span>
+    {/if}
+  </button>
+
+  {#if !collapsed}
+    {#if todos === null}
+      <div class="todo-body">
+        <span class="todo-fallback">{chunk.input}</span>
+      </div>
+    {:else if todos.length === 0}
+      <div class="todo-body">
+        <span class="todo-empty">No tasks</span>
+      </div>
+    {:else}
+      <div class="todo-progress-bar">
+        {#each todos as todo, i (todo.id ?? i)}
+          <div
+            class="todo-segment"
+            class:completed={todo.status === "completed"}
+            class:in-progress={todo.status === "in_progress"}
+            style="flex:{1}"
+          ></div>
+        {/each}
+      </div>
+      <div class="todo-body">
+        {#each todos as todo, i (todo.id ?? i)}
+          <div class="todo-item" class:completed={todo.status === "completed"}>
+            {#if todo.priority === "high"}
+              <span class="todo-priority-dot high"></span>
+            {/if}
+            <span class="todo-status-icon">
+              {#if todo.status === "completed"}
+                <CheckCircle2 size={14} strokeWidth={2} />
+              {:else if todo.status === "in_progress"}
+                <Loader size={14} strokeWidth={2} />
+              {:else}
+                <Circle size={14} strokeWidth={1.5} />
+              {/if}
+            </span>
+            <span class="todo-content">{todo.content}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .todo-block {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--bg-card);
+  }
+
+  .todo-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.4rem 0.7rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.73rem;
+    text-align: left;
+  }
+
+  .todo-header:hover {
+    background: color-mix(in srgb, var(--accent) 5%, transparent);
+  }
+
+  .todo-chevron {
+    font-size: 0.65rem;
+    opacity: 0.5;
+    transition: transform 0.15s ease;
+  }
+
+  .todo-chevron.collapsed {
+    transform: rotate(-90deg);
+  }
+
+  .todo-icon {
+    display: flex;
+    align-items: center;
+    opacity: 0.6;
+    color: var(--accent);
+  }
+
+  .todo-label {
+    color: var(--text-secondary);
+  }
+
+  .todo-count {
+    margin-left: auto;
+    color: var(--text-dim);
+    font-size: 0.7rem;
+  }
+
+  .todo-progress-bar {
+    display: flex;
+    height: 3px;
+    gap: 1px;
+    background: var(--bg-hover);
+  }
+
+  .todo-segment {
+    background: var(--bg-hover);
+    transition: background 0.2s ease;
+  }
+
+  .todo-segment.completed {
+    background: var(--status-ok, #7e9e6b);
+  }
+
+  .todo-segment.in-progress {
+    background: var(--accent);
+  }
+
+  .todo-body {
+    overflow-y: auto;
+    max-height: 300px;
+    padding: 0.35rem 0;
+  }
+
+  .todo-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.2rem 0.7rem;
+    font-size: 0.78rem;
+    color: var(--text-primary);
+  }
+
+  .todo-item.completed {
+    color: var(--text-dim);
+  }
+
+  .todo-item.completed .todo-content {
+    text-decoration: line-through;
+    opacity: 0.6;
+  }
+
+  .todo-priority-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .todo-priority-dot.high {
+    background: var(--status-fail, #b5564e);
+  }
+
+  .todo-status-icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .todo-item:not(.completed) .todo-status-icon {
+    color: var(--text-dim);
+  }
+
+  .todo-item.completed .todo-status-icon {
+    color: var(--status-ok, #7e9e6b);
+  }
+
+  /* in_progress items get amber spinning icon */
+  .todo-item:not(.completed) :global(.lucide-loader) {
+    color: var(--accent);
+    animation: spin 2s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  .todo-content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .todo-fallback {
+    padding: 0.4rem 0.7rem;
+    font-family: var(--font-mono);
+    font-size: 0.73rem;
+    color: var(--text-dim);
+    word-break: break-all;
+  }
+
+  .todo-empty {
+    padding: 0.4rem 0.7rem;
+    font-size: 0.75rem;
+    color: var(--text-dim);
+    font-style: italic;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Renders agent's `TodoWrite` tool calls as a dedicated visual block instead of a generic tool pill
- Shows a segmented progress bar (olive/amber/dim) and checklist with status icons (completed, in-progress spinning, pending)
- Preserves full `todos` JSON in Rust backend (same pattern as `AskUserQuestion`)
- Latest TodoWrite block is always expanded; older ones auto-collapse to a summary line

## Test plan
- [x] `cargo check` passes
- [x] `bun run check` passes (no new errors)
- [ ] Send a message that triggers TodoWrite — verify expanded block with progress bar + checklist
- [ ] Verify older TodoWrite blocks collapse to single-line summary
- [ ] Verify clicking collapsed header toggles expansion
- [ ] Verify persisted messages render correctly after app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)