### PR TITLE
fix: grant agent read access to images directory for pasted images

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -347,6 +347,10 @@ pub fn send_message(
         cmd.arg("--dangerously-skip-permissions");
     }
 
+    // Grant agent access to the images directory so it can read pasted images
+    let images_dir = data_dir.join("images");
+    cmd.arg("--add-dir").arg(&images_dir);
+
     // Thinking mode: use high effort for deeper reasoning
     if thinking_mode {
         cmd.args(["--effort", "high"]);


### PR DESCRIPTION
## Summary
- Adds `--add-dir` flag pointing to `<data_dir>/images/` when spawning the Claude CLI agent
- Fixes pasted images from TaskPopover being inaccessible to the agent due to the images directory being outside the worktree (project scope)

## Test plan
- [ ] Create a todo card with a pasted image, spawn it, verify the agent can read the image
- [ ] Verify ChatPanel pasted images still work
- [ ] Test both plan mode and non-plan mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)