### PR TITLE
fix: prevent kanban board overflow by resetting min-width constraints

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,6 +15,8 @@
         "title": "korlap",
         "width": 1100,
         "height": 700,
+        "minWidth": 760,
+        "minHeight": 400,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true
       }

--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -235,7 +235,7 @@
     padding: 0.75rem;
     flex: 1;
     min-height: 0;
-    overflow-x: auto;
+    min-width: 0;
   }
 
   .empty-hint {

--- a/src/lib/components/KanbanColumn.svelte
+++ b/src/lib/components/KanbanColumn.svelte
@@ -36,7 +36,7 @@
 <style>
   .column {
     flex: 1;
-    min-width: 220px;
+    min-width: 0;
     max-width: 380px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Remove `overflow-x: auto` from kanban board and `min-width: 220px` from columns, replacing both with `min-width: 0` so columns compress naturally at narrow widths instead of causing horizontal scroll
- Add `minWidth: 760` and `minHeight: 400` to the Tauri window config to prevent the window from being resized too small for 4 columns

## Test plan
- [ ] Resize the app window to its minimum width and verify no horizontal scrollbar appears on the kanban board
- [ ] Verify all 4 kanban columns remain visible and usable at minimum window width
- [ ] Verify columns still respect max-width at larger window sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)