### PR TITLE
fix: replace home button text with chevron-left icon

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -2,7 +2,7 @@
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import type { RepoDetail, WorkspaceInfo } from "$lib/ipc";
   import { syncMain, getRepoHead, checkoutDefaultBranch, checkMainBehind } from "$lib/ipc";
-  import { Settings, Check, Plus, RefreshCw, AlertTriangle } from "lucide-svelte";
+  import { Settings, Check, Plus, RefreshCw, AlertTriangle, ChevronLeft } from "lucide-svelte";
   import Dropdown from "./Dropdown.svelte";
   import { addToast } from "$lib/stores/toasts.svelte";
 
@@ -128,7 +128,7 @@
   ondblclick={handleDoubleClick}
 >
   <div class="titlebar-left">
-    <button class="home-btn" onclick={onGoHome} title="Home">K</button>
+    <button class="home-btn" onclick={onGoHome} title="Home"><ChevronLeft size={14} strokeWidth={2.5} /></button>
     <div class="btn-group">
       <Dropdown bind:this={dropdownRef} onclose={onDropdownClose}>
         {#snippet trigger()}
@@ -255,11 +255,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 12px;
-    font-weight: 700;
     color: var(--accent);
     cursor: pointer;
-    font-family: inherit;
     padding: 0;
     flex-shrink: 0;
     transition: border-color 0.15s ease;


### PR DESCRIPTION
## Summary
- Replaced the "K" text in the home button with a `ChevronLeft` icon from lucide-svelte
- Removed unnecessary font-related CSS properties (`font-size`, `font-weight`, `font-family`) from `.home-btn` since the button now contains an SVG icon instead of text

## Test plan
- [ ] Verify the chevron-left icon renders correctly in the title bar
- [ ] Verify hover state still works (border color change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)