### PR TITLE
fix: prevent review button content from overflowing rounded border

### DIFF
--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -566,6 +566,7 @@
     align-items: stretch;
     border: 1px solid var(--border-light);
     border-radius: 5px;
+    overflow: hidden;
   }
 
   .pr-link-btn {


### PR DESCRIPTION
## Summary
- Added `overflow: hidden` to `.action-group` in WorkspacePanel so child buttons are clipped to the parent's rounded corners

## Test plan
- [ ] Verify the review/merge action buttons no longer visually overflow the rounded `.action-group` container

🤖 Generated with [Claude Code](https://claude.com/claude-code)