### PR TITLE
feat: add task dependency tracking and graph visualization for autopilot

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -807,6 +807,75 @@ pub async fn prioritize_todos(
     .map_err(|e| format!("Task failed: {}", e))?
 }
 
+#[tauri::command]
+pub async fn determine_dependencies(
+    todo_json: String,
+    state: State<'_, Arc<Mutex<AppState>>>,
+) -> Result<String, String> {
+    let data_dir = {
+        let st = state.lock().map_err(|e| e.to_string())?;
+        st.data_dir.clone()
+    };
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let system_prompt = "You are a task dependency analyzer for a software project. Given a list of TODO items \
+            (each with id, title, description), determine which tasks depend on other tasks. Task A depends on task B \
+            if A requires B's code changes to exist first — e.g., \"write API tests\" depends on \"build the API endpoint\". \
+            Only include direct dependencies, not transitive ones. Return ONLY a JSON object mapping task IDs to arrays \
+            of dependency task IDs. Only include entries for tasks that have dependencies. \
+            Example: {\"id2\": [\"id1\"], \"id3\": [\"id1\"]}. If no dependencies exist, return: {}";
+
+        let claude_bin = get_shell_env()
+            .claude_path
+            .as_deref()
+            .unwrap_or("claude");
+
+        let mut cmd = std::process::Command::new(claude_bin);
+        cmd.arg("-p").arg(&todo_json);
+        cmd.args(["--output-format", "text"]);
+        cmd.args(["--max-turns", "1"]);
+        cmd.arg("--system-prompt").arg(system_prompt);
+        cmd.current_dir(&data_dir);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::null());
+        inject_shell_env(&mut cmd);
+
+        let child = cmd
+            .spawn()
+            .map_err(|e| format!("Failed to spawn claude: {}", e))?;
+
+        let pid = child.id();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let output = child.wait_with_output();
+            let _ = tx.send(output);
+        });
+
+        match rx.recv_timeout(std::time::Duration::from_secs(60)) {
+            Ok(Ok(output)) if output.status.success() => {
+                let raw = strip_ansi(
+                    &String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                );
+                let json_str = strip_json_fences(&raw);
+                // Validate it's valid JSON before returning
+                let _: serde_json::Value = serde_json::from_str(json_str)
+                    .map_err(|e| format!("Failed to parse dependencies: {} — raw: {}", e, raw))?;
+                Ok(json_str.to_string())
+            }
+            Ok(Ok(_)) => Err("Claude exited with non-zero status".to_string()),
+            Ok(Err(e)) => Err(format!("Claude failed: {}", e)),
+            Err(_) => {
+                let _ = std::process::Command::new("kill")
+                    .args(["-9", &pid.to_string()])
+                    .output();
+                Err("Timed out determining dependencies".to_string())
+            }
+        }
+    })
+    .await
+    .map_err(|e| format!("Task failed: {}", e))?
+}
+
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct AutopilotAction {
     pub response: String,

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -196,6 +196,7 @@ pub async fn create_staging_workspace(
         created_at: now_unix(),
         task_title: Some("Staging".to_string()),
         task_description: None,
+        source_todo_id: None,
     };
 
     let mut st = state.lock().map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -47,6 +47,7 @@ pub async fn create_workspace(
     repo_id: String,
     task_title: Option<String>,
     task_description: Option<String>,
+    source_todo_id: Option<String>,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<WorkspaceInfo, String> {
     let (repo_path, gh_profile) = {
@@ -205,6 +206,7 @@ pub async fn create_workspace(
         created_at: now_unix(),
         task_title,
         task_description,
+        source_todo_id,
     };
 
     // Check if there's a setup script to run

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,7 @@ pub fn run() {
             commands::agent::generate_commit_message,
             commands::agent::suggest_replies,
             commands::agent::prioritize_todos,
+            commands::agent::determine_dependencies,
             commands::agent::interpret_autopilot_command,
             // scripts
             commands::scripts::run_script,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -32,6 +32,8 @@ pub struct WorkspaceInfo {
     pub task_title: Option<String>,
     #[serde(default)]
     pub task_description: Option<String>,
+    #[serde(default)]
+    pub source_todo_id: Option<String>,
 }
 
 pub struct AgentHandle {

--- a/src/lib/components/DependencyGraph.svelte
+++ b/src/lib/components/DependencyGraph.svelte
@@ -1,0 +1,395 @@
+<script lang="ts">
+  import type { WorkspaceInfo, PrStatus } from "$lib/ipc";
+  import { X } from "lucide-svelte";
+
+  interface TodoItem {
+    id: string;
+    repo_id: string;
+    title: string;
+    description: string;
+    depends_on?: string[];
+    ready?: boolean;
+  }
+
+  interface Props {
+    todos: TodoItem[];
+    workspaces: WorkspaceInfo[];
+    prStatusMap: Map<string, PrStatus>;
+    onClose: () => void;
+  }
+
+  let { todos, workspaces, prStatusMap, onClose }: Props = $props();
+
+  // ── Graph node types ──────────────────────────────────
+  type NodeStatus = "ready" | "blocked" | "in-progress" | "review" | "done";
+
+  interface GraphNode {
+    id: string; // todo id or source_todo_id
+    label: string;
+    status: NodeStatus;
+    x: number;
+    y: number;
+  }
+
+  interface GraphEdge {
+    from: string;
+    to: string;
+  }
+
+  // ── Build graph from todos + workspaces ───────────────
+  const NODE_W = 180;
+  const NODE_H = 44;
+  const H_GAP = 80;
+  const V_GAP = 24;
+
+  function getWsStatus(ws: WorkspaceInfo): NodeStatus {
+    const pr = prStatusMap.get(ws.id);
+    if (pr?.state === "merged") return "done";
+    if (pr?.state === "open") return "review";
+    return "in-progress";
+  }
+
+  function isTodoBlocked(todo: TodoItem): boolean {
+    if (!todo.depends_on || todo.depends_on.length === 0) return false;
+    return todo.depends_on.some(depId => {
+      if (todos.some(t => t.id === depId)) return true;
+      const ws = workspaces.find(w => w.source_todo_id === depId);
+      if (!ws) return false;
+      const pr = prStatusMap.get(ws.id);
+      return pr?.state !== "merged";
+    });
+  }
+
+  // Collect all node IDs that participate in dependencies
+  function buildGraph(): { nodes: GraphNode[]; edges: GraphEdge[] } {
+    const nodeMap = new Map<string, { label: string; status: NodeStatus; deps: string[] }>();
+    const edges: GraphEdge[] = [];
+
+    // Add all todos
+    for (const todo of todos) {
+      nodeMap.set(todo.id, {
+        label: todo.title,
+        status: isTodoBlocked(todo) ? "blocked" : "ready",
+        deps: todo.depends_on ?? [],
+      });
+    }
+
+    // Add all workspaces that originated from tasks (have task_title)
+    for (const ws of workspaces) {
+      if (!ws.task_title) continue;
+      const nodeId = ws.source_todo_id ?? `ws-${ws.id}`;
+      // Don't overwrite if a todo with this ID still exists
+      if (nodeMap.has(nodeId)) continue;
+      nodeMap.set(nodeId, {
+        label: ws.task_title,
+        status: getWsStatus(ws),
+        deps: [],
+      });
+    }
+
+    // Build edges from depends_on
+    for (const todo of todos) {
+      if (!todo.depends_on) continue;
+      for (const depId of todo.depends_on) {
+        if (nodeMap.has(depId)) {
+          edges.push({ from: depId, to: todo.id });
+        }
+      }
+    }
+
+    // Show all nodes — todos and task-originated workspaces
+    const filteredIds = new Set<string>(nodeMap.keys());
+
+    // Topological rank assignment (Kahn's algorithm)
+    const inDegree = new Map<string, number>();
+    const adj = new Map<string, string[]>();
+    for (const id of filteredIds) {
+      inDegree.set(id, 0);
+      adj.set(id, []);
+    }
+    for (const e of edges) {
+      if (!filteredIds.has(e.from) || !filteredIds.has(e.to)) continue;
+      adj.get(e.from)!.push(e.to);
+      inDegree.set(e.to, (inDegree.get(e.to) ?? 0) + 1);
+    }
+
+    const rank = new Map<string, number>();
+    const queue: string[] = [];
+    for (const [id, deg] of inDegree) {
+      if (deg === 0) { queue.push(id); rank.set(id, 0); }
+    }
+
+    while (queue.length > 0) {
+      const curr = queue.shift()!;
+      const currRank = rank.get(curr) ?? 0;
+      for (const next of adj.get(curr) ?? []) {
+        const nextRank = Math.max(rank.get(next) ?? 0, currRank + 1);
+        rank.set(next, nextRank);
+        const newDeg = (inDegree.get(next) ?? 1) - 1;
+        inDegree.set(next, newDeg);
+        if (newDeg === 0) queue.push(next);
+      }
+    }
+
+    // Handle nodes not reached (cycles) — assign max rank + 1
+    const maxRank = Math.max(0, ...rank.values());
+    for (const id of filteredIds) {
+      if (!rank.has(id)) rank.set(id, maxRank + 1);
+    }
+
+    // Group by rank for layout
+    const rankGroups = new Map<number, string[]>();
+    for (const [id, r] of rank) {
+      if (!rankGroups.has(r)) rankGroups.set(r, []);
+      rankGroups.get(r)!.push(id);
+    }
+
+    // Position nodes
+    const nodes: GraphNode[] = [];
+    const sortedRanks = [...rankGroups.keys()].sort((a, b) => a - b);
+    for (const r of sortedRanks) {
+      const group = rankGroups.get(r)!;
+      const colX = r * (NODE_W + H_GAP) + 40;
+      const totalHeight = group.length * NODE_H + (group.length - 1) * V_GAP;
+      const startY = Math.max(40, (400 - totalHeight) / 2);
+      for (let i = 0; i < group.length; i++) {
+        const id = group[i];
+        const n = nodeMap.get(id);
+        if (!n) continue;
+        nodes.push({
+          id,
+          label: n.label,
+          status: n.status,
+          x: colX,
+          y: startY + i * (NODE_H + V_GAP),
+        });
+      }
+    }
+
+    return { nodes, edges: edges.filter(e => filteredIds.has(e.from) && filteredIds.has(e.to)) };
+  }
+
+  let graph = $derived(buildGraph());
+
+  // SVG dimensions
+  let svgWidth = $derived(
+    Math.max(600, graph.nodes.reduce((m, n) => Math.max(m, n.x + NODE_W + 40), 0))
+  );
+  let svgHeight = $derived(
+    Math.max(400, graph.nodes.reduce((m, n) => Math.max(m, n.y + NODE_H + 40), 0))
+  );
+
+  // Edge path generation
+  function edgePath(e: GraphEdge): string {
+    const fromNode = graph.nodes.find(n => n.id === e.from);
+    const toNode = graph.nodes.find(n => n.id === e.to);
+    if (!fromNode || !toNode) return "";
+
+    const x1 = fromNode.x + NODE_W;
+    const y1 = fromNode.y + NODE_H / 2;
+    const x2 = toNode.x;
+    const y2 = toNode.y + NODE_H / 2;
+    const cx = (x1 + x2) / 2;
+
+    return `M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`;
+  }
+
+  function statusColor(status: NodeStatus): string {
+    switch (status) {
+      case "ready": return "var(--accent)";
+      case "blocked": return "var(--text-dim)";
+      case "in-progress": return "var(--accent)";
+      case "review": return "var(--status-pr-open, var(--accent))";
+      case "done": return "var(--diff-add)";
+    }
+  }
+
+  function handleBackdrop(e: MouseEvent) {
+    if ((e.target as HTMLElement).classList.contains("dep-graph-overlay")) onClose();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") onClose();
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div class="dep-graph-overlay" onclick={handleBackdrop}>
+  <div class="dep-graph-panel">
+    <div class="dep-graph-header">
+      <h3>Task Dependencies</h3>
+      <button class="close-btn" onclick={onClose}><X size={14} /></button>
+    </div>
+
+    {#if graph.nodes.length === 0}
+      <div class="empty-state">No tasks to display</div>
+    {:else}
+      <div class="dep-graph-scroll">
+        <svg width={svgWidth} height={svgHeight}>
+          <defs>
+            <marker
+              id="arrowhead"
+              markerWidth="8"
+              markerHeight="6"
+              refX="8"
+              refY="3"
+              orient="auto"
+            >
+              <polygon points="0 0, 8 3, 0 6" fill="var(--text-dim)" />
+            </marker>
+          </defs>
+
+          <!-- Edges -->
+          {#each graph.edges as edge}
+            <path
+              d={edgePath(edge)}
+              fill="none"
+              stroke="var(--text-dim)"
+              stroke-width="1.5"
+              stroke-opacity="0.5"
+              marker-end="url(#arrowhead)"
+            />
+          {/each}
+
+          <!-- Nodes -->
+          {#each graph.nodes as node}
+            <g transform="translate({node.x}, {node.y})">
+              <rect
+                width={NODE_W}
+                height={NODE_H}
+                rx="8"
+                fill="var(--bg-card)"
+                stroke={statusColor(node.status)}
+                stroke-width={node.status === "blocked" ? "1" : "1.5"}
+                stroke-dasharray={node.status === "blocked" ? "4 3" : "none"}
+                opacity={node.status === "done" ? 0.6 : 1}
+              />
+              {#if node.status === "in-progress"}
+                <rect
+                  width={NODE_W}
+                  height={NODE_H}
+                  rx="8"
+                  fill="none"
+                  stroke={statusColor(node.status)}
+                  stroke-width="1.5"
+                  class="pulse-ring"
+                />
+              {/if}
+              <text
+                x={NODE_W / 2}
+                y={NODE_H / 2 + 1}
+                text-anchor="middle"
+                dominant-baseline="middle"
+                fill={node.status === "blocked" ? "var(--text-dim)" : "var(--text-primary)"}
+                font-size="11"
+                font-weight="600"
+                font-family="var(--font-family, 'Space Grotesk', sans-serif)"
+              >
+                {node.label.length > 22 ? node.label.slice(0, 20) + "..." : node.label}
+              </text>
+              <text
+                x={NODE_W / 2}
+                y={NODE_H - 6}
+                text-anchor="middle"
+                fill={statusColor(node.status)}
+                font-size="8"
+                font-weight="700"
+                font-family="var(--font-family, 'Space Grotesk', sans-serif)"
+                letter-spacing="0.5"
+              >
+                {node.status.replace("-", " ").toUpperCase()}
+              </text>
+            </g>
+          {/each}
+        </svg>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .dep-graph-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .dep-graph-panel {
+    background: var(--bg-base);
+    border: 1px solid var(--border-light);
+    border-radius: 12px;
+    width: min(90vw, 900px);
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+  }
+
+  .dep-graph-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-light);
+  }
+
+  .dep-graph-header h3 {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  .close-btn {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    background: transparent;
+    border: 1px solid var(--border-light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-dim);
+    cursor: pointer;
+    padding: 0;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .close-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  .dep-graph-scroll {
+    overflow: auto;
+    padding: 1rem;
+    flex: 1;
+  }
+
+  .dep-graph-scroll svg {
+    display: block;
+  }
+
+  .empty-state {
+    padding: 3rem;
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 0.85rem;
+  }
+
+  :global(.pulse-ring) {
+    animation: dep-pulse 2s ease-in-out infinite;
+  }
+
+  @keyframes dep-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+  }
+</style>

--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -18,6 +18,7 @@
     planMode?: boolean;
     thinkingMode?: boolean;
     ready?: boolean;
+    depends_on?: string[];
     created_at: number;
   }
 

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -2,7 +2,7 @@
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import type { RepoDetail, WorkspaceInfo } from "$lib/ipc";
   import { syncMain, getRepoHead, checkoutDefaultBranch, checkMainBehind } from "$lib/ipc";
-  import { Settings, Check, Plus, RefreshCw, AlertTriangle, ChevronLeft, Zap } from "lucide-svelte";
+  import { Settings, Check, Plus, RefreshCw, AlertTriangle, ChevronLeft, Zap, Network } from "lucide-svelte";
   import Dropdown from "./Dropdown.svelte";
   import { addToast } from "$lib/stores/toasts.svelte";
 
@@ -22,9 +22,10 @@
     autopilotEnabled?: boolean;
     onAutopilotToggle?: () => void;
     autopilotStatus?: string;
+    onShowDepGraph?: () => void;
   }
 
-  let { repos, activeRepo, selectedWs, appMode, onModeChange, onSelectRepo, onSettings, onGoHome, highlightedRepoIndex, onDropdownClose, autopilotEnabled = false, onAutopilotToggle, autopilotStatus }: Props =
+  let { repos, activeRepo, selectedWs, appMode, onModeChange, onSelectRepo, onSettings, onGoHome, highlightedRepoIndex, onDropdownClose, autopilotEnabled = false, onAutopilotToggle, autopilotStatus, onShowDepGraph }: Props =
     $props();
 
   let dropdownRef: Dropdown | undefined = $state();
@@ -222,6 +223,15 @@
       Autopilot
       <kbd class="mode-hint">⌘3</kbd>
     </button>
+    {#if autopilotEnabled}
+      <button
+        class="dep-graph-btn"
+        onclick={onShowDepGraph}
+        title="Task dependencies"
+      >
+        <Network size={12} />
+      </button>
+    {/if}
   </div>
 </header>
 
@@ -544,6 +554,26 @@
   @keyframes autopilot-glow {
     0%, 100% { box-shadow: none; }
     50% { box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 25%, transparent); }
+  }
+
+  .dep-graph-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+    border-radius: 5px;
+    color: var(--accent);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .dep-graph-btn:hover {
+    background: color-mix(in srgb, var(--accent) 20%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 50%, transparent);
   }
 
   .autopilot-status {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -28,6 +28,7 @@ export interface WorkspaceInfo {
   created_at: number;
   task_title?: string | null;
   task_description?: string | null;
+  source_todo_id?: string | null;
 }
 
 export interface ToolUseInfo {
@@ -155,11 +156,13 @@ export async function createWorkspace(
   repoId: string,
   taskTitle?: string,
   taskDescription?: string,
+  sourceTodoId?: string,
 ): Promise<WorkspaceInfo> {
   return invoke<WorkspaceInfo>("create_workspace", {
     repoId,
     taskTitle: taskTitle ?? null,
     taskDescription: taskDescription ?? null,
+    sourceTodoId: sourceTodoId ?? null,
   });
 }
 
@@ -591,6 +594,11 @@ export interface AutopilotAction {
   action_type: string;
   todo_ids: string[];
   reorder: string[];
+}
+
+export async function determineDependencies(todoJson: string): Promise<Record<string, string[]>> {
+  const raw = await invoke<string>("determine_dependencies", { todoJson });
+  return JSON.parse(raw);
 }
 
 export async function interpretAutopilotCommand(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,7 @@
     removeStagingWorkspace,
     getSystemResources,
     prioritizeTodos,
+    determineDependencies,
     interpretAutopilotCommand,
     type RepoDetail,
     type RepoSettings,
@@ -68,6 +69,7 @@
   import type { Mention } from "$lib/components/MentionInput.svelte";
   import RepoSettingsPanel from "$lib/components/RepoSettings.svelte";
   import SearchModal from "$lib/components/SearchModal.svelte";
+  import DependencyGraph from "$lib/components/DependencyGraph.svelte";
   import { type ReviewState } from "$lib/components/ReviewPill.svelte";
   import Toasts from "$lib/components/Toasts.svelte";
   import { addToast } from "$lib/stores/toasts.svelte";
@@ -137,6 +139,10 @@
     autopilotEvents.push({ id: crypto.randomUUID(), time: Date.now(), type, message, wsId, wsName });
     if (autopilotEvents.length > 200) autopilotEvents.splice(0, autopilotEvents.length - 200);
   }
+
+  // ── Dependency graph overlay ─────────────────────────────
+  let showDepGraph = $state(false);
+  $effect(() => { if (!autopilotEnabled) showDepGraph = false; });
 
   // ── Staging state ──────────────────────────────────────
   let stagingWsId = $state<string | null>(null);
@@ -406,6 +412,7 @@
     planMode?: boolean;
     thinkingMode?: boolean;
     ready?: boolean;
+    depends_on?: string[];
     created_at: number;
   }
   let todos = $state<TodoItem[]>([]);
@@ -748,7 +755,7 @@
         created_at: Date.now() / 1000,
       });
       persistTodos();
-      if (autopilotEnabled) reprioritizeTodos();
+      if (autopilotEnabled) { await updateDependencies(); reprioritizeTodos(); }
     } catch (e) {
       addToast(`Failed to save images: ${e}`);
     }
@@ -768,6 +775,7 @@
       todo.planMode = data.planMode || undefined;
       todo.thinkingMode = data.thinkingMode || undefined;
       persistTodos();
+      if (autopilotEnabled) updateDependencies();
     } catch (e) {
       addToast(`Failed to save images: ${e}`);
     }
@@ -817,7 +825,7 @@
     }
     autopilotPrioritizing = true;
     try {
-      const todoData = readyTodos.map(t => ({ id: t.id, title: t.title, description: t.description }));
+      const todoData = readyTodos.map(t => ({ id: t.id, title: t.title, description: t.description, depends_on: t.depends_on ?? [] }));
       const ordered = await prioritizeTodos(JSON.stringify(todoData));
       autopilotPrioritizedIds = ordered.filter(id => readyTodos.some(t => t.id === id));
       addAutopilotEvent("prioritized", `Prioritized ${autopilotPrioritizedIds.length} tasks`);
@@ -826,6 +834,39 @@
       autopilotPrioritizedIds = readyTodos.map(t => t.id);
     } finally {
       autopilotPrioritizing = false;
+    }
+  }
+
+  // ── Dependency tracking ─────────────────────────────────
+  function isDependencyResolved(depId: string): boolean {
+    // Still in todo list → not even started
+    if (todos.some(t => t.id === depId)) return false;
+    // Find workspace spawned from this todo
+    const ws = workspaces.find(w => w.source_todo_id === depId);
+    if (!ws) return true; // todo deleted without spawning → treat as resolved
+    // Resolved only when PR is merged
+    const pr = prStatusMap.get(ws.id);
+    return pr?.state === "merged";
+  }
+
+  function isTodoBlocked(todo: TodoItem): boolean {
+    return todo.depends_on?.some(depId => !isDependencyResolved(depId)) ?? false;
+  }
+
+  async function updateDependencies() {
+    if (!activeRepo) return;
+    const allTodos = todos.filter(t => t.repo_id === activeRepo!.id);
+    if (allTodos.length <= 1) return;
+    try {
+      const todoData = allTodos.map(t => ({ id: t.id, title: t.title, description: t.description }));
+      const deps = await determineDependencies(JSON.stringify(todoData));
+      for (const todo of allTodos) {
+        const depList = deps[todo.id];
+        todo.depends_on = depList && depList.length > 0 ? depList : undefined;
+      }
+      persistTodos();
+    } catch {
+      // Non-fatal: tasks just won't have dep info
     }
   }
 
@@ -925,8 +966,8 @@
         }
       }
 
-      // 2. Auto-pickup: spawn from next ready TODO if under limit
-      const readyTodos = todos.filter(t => t.ready);
+      // 2. Auto-pickup: spawn from next ready TODO if under limit (skip blocked)
+      const readyTodos = todos.filter(t => t.ready && !isTodoBlocked(t));
       if (activeAgentCount < maxConcurrentAgents && !creatingWsId && readyTodos.length > 0) {
         // Pick from prioritized list, or first ready todo
         const nextId = autopilotPrioritizedIds.find(id => readyTodos.some(t => t.id === id))
@@ -1038,13 +1079,16 @@
 
   // Called when autopilot is toggled on — fetch resources, prioritize, evaluate.
   // NOT a $effect — avoids reactive loops that re-trigger on state mutations.
-  function onAutopilotActivated() {
+  async function onAutopilotActivated() {
     getSystemResources().then(res => {
       // Claude agents are I/O-bound, not memory-hungry. Use total RAM (not available — macOS
       // reports free-minus-cache which is always tiny) and be generous with the ratio.
       maxConcurrentAgents = Math.max(2, Math.min(Math.floor(res.cpu_cores / 2), Math.floor(res.memory_gb / 4)));
     }).catch(() => { maxConcurrentAgents = 3; });
-    reprioritizeTodos();
+    // Dependencies + prioritization must complete before evaluation — otherwise
+    // all tasks spawn unconditionally because depends_on is still empty.
+    await updateDependencies();
+    await reprioritizeTodos();
     rebuildStaging();
     evaluateAutopilot();
   }
@@ -1117,6 +1161,7 @@
       created_at: Date.now() / 1000,
       task_title: todo.title,
       task_description: todo.description || null,
+      source_todo_id: todoId,
     };
     creatingWsId = tempId;
     workspaces.push(placeholder);
@@ -1126,7 +1171,7 @@
     handleRemoveTodo(todoId);
 
     try {
-      const ws = await createWorkspace(repoId, todo.title, todo.description || undefined);
+      const ws = await createWorkspace(repoId, todo.title, todo.description || undefined, todoId);
       const idx = workspaces.findIndex((w) => w.id === tempId);
       if (idx >= 0) workspaces[idx] = ws;
       selectedWsId = ws.id;
@@ -1938,6 +1983,7 @@
       {autopilotEnabled}
       onAutopilotToggle={() => { autopilotEnabled = !autopilotEnabled; if (autopilotEnabled) onAutopilotActivated(); }}
       autopilotStatus={autopilotEnabled ? `${activeAgentCount}/${maxConcurrentAgents} agents · ${todos.filter(t => t.ready).length} queued` : undefined}
+      onShowDepGraph={() => { showDepGraph = !showDepGraph; }}
     />
 
     {#if reviewAlertWs}
@@ -2063,6 +2109,14 @@
       </div>
     </div>
 
+    {#if showDepGraph}
+      <DependencyGraph
+        todos={todoItems}
+        workspaces={activeWorkspaces}
+        {prStatusMap}
+        onClose={() => { showDepGraph = false; }}
+      />
+    {/if}
 
     {#if showSearchModal && selectedWsId}
       <SearchModal


### PR DESCRIPTION
## Summary
- Adds `depends_on` field to tasks, with dependencies determined by Claude CLI analysis
- Implements hard blocking: tasks won't auto-pickup until all dependency PRs are merged
- Adds `source_todo_id` to `WorkspaceInfo` to track todo→workspace lifecycle
- New SVG dependency graph visualization (button in TitleBar, visible when autopilot is on)
- Dependencies are re-evaluated when todos are added/edited or autopilot is activated

## Test plan
- [ ] Enable autopilot with multiple interdependent tasks — verify blocked tasks aren't picked up
- [ ] Verify dependency graph renders correctly with proper node statuses
- [ ] Confirm graph auto-hides when autopilot is turned off
- [ ] Test backward compatibility with existing workspaces/todos (no `source_todo_id`/`depends_on`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)