### PR TITLE
feat: create new GitHub repo from home screen

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -269,40 +269,34 @@ pub async fn list_gh_repos(profile: String, search: Option<String>) -> Result<Ve
     .map_err(|e| format!("Task failed: {}", e))?
 }
 
-#[tauri::command]
-pub fn clone_repo(
-    clone_url: String,
-    repo_name: String,
-    dest_path: Option<String>,
-    profile: String,
+/// Shared helper: clone a repo and register it in app state.
+pub(super) fn clone_and_register(
+    clone_url: &str,
+    repo_name: &str,
+    dest_path: Option<&str>,
+    profile: &str,
+    token: &Option<String>,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<super::repo::RepoDetail, String> {
-    let token = resolve_gh_token(&Some(profile.clone()));
-
-    // Determine destination
-    let dest = if let Some(ref p) = dest_path {
+    let dest = if let Some(p) = dest_path {
         std::path::PathBuf::from(p)
     } else {
-        // Default to ~/Developer/<repo-name>
         let home = std::env::var("HOME").map_err(|_| "Cannot determine HOME directory")?;
-        std::path::PathBuf::from(home).join("Developer").join(&repo_name)
+        std::path::PathBuf::from(home).join("Developer").join(repo_name)
     };
 
     if dest.exists() {
-        // If it already exists and is a git repo, just add it
         if dest.join(".git").exists() {
-            return super::repo::register_repo(dest, Some(profile), state);
+            return super::repo::register_repo(dest, Some(profile.to_string()), state);
         }
         return Err(format!("Destination already exists: {}", dest.display()));
     }
 
-    // Create parent dir if needed
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("Failed to create directory: {}", e))?;
     }
 
-    // Clone with token auth
     let mut cmd = std::process::Command::new("git");
     if let Some(ref t) = token {
         cmd.args([
@@ -318,7 +312,7 @@ pub fn clone_repo(
             ),
         ]);
     }
-    cmd.args(["clone", &clone_url, &dest.to_string_lossy()]);
+    cmd.args(["clone", clone_url, &dest.to_string_lossy()]);
     inject_shell_env(&mut cmd);
 
     let output = cmd.output().map_err(|e| format!("Failed to run git clone: {}", e))?;
@@ -327,7 +321,85 @@ pub fn clone_repo(
         return Err(format!("git clone failed: {}", stderr));
     }
 
-    super::repo::register_repo(dest, Some(profile), state)
+    super::repo::register_repo(dest, Some(profile.to_string()), state)
+}
+
+#[tauri::command]
+pub fn clone_repo(
+    clone_url: String,
+    repo_name: String,
+    dest_path: Option<String>,
+    profile: String,
+    state: State<'_, Arc<Mutex<AppState>>>,
+) -> Result<super::repo::RepoDetail, String> {
+    let token = resolve_gh_token(&Some(profile.clone()));
+    clone_and_register(
+        &clone_url,
+        &repo_name,
+        dest_path.as_deref(),
+        &profile,
+        &token,
+        state,
+    )
+}
+
+// ── Create repo on GitHub ────────────────────────────────────────────
+
+#[derive(Clone, serde::Deserialize)]
+pub struct CreateRepoOptions {
+    pub name: String,
+    pub private: bool,
+    pub description: Option<String>,
+    pub add_readme: bool,
+}
+
+#[tauri::command]
+pub fn create_gh_repo(
+    options: CreateRepoOptions,
+    profile: String,
+    state: State<'_, Arc<Mutex<AppState>>>,
+) -> Result<super::repo::RepoDetail, String> {
+    let token = resolve_gh_token(&Some(profile.clone()));
+
+    let full_name = format!("{}/{}", profile, options.name);
+
+    // Create the repo on GitHub
+    let mut cmd = std::process::Command::new("gh");
+    cmd.args(["repo", "create", &full_name]);
+    if options.private {
+        cmd.arg("--private");
+    } else {
+        cmd.arg("--public");
+    }
+    if let Some(ref desc) = options.description {
+        if !desc.is_empty() {
+            cmd.args(["-d", desc]);
+        }
+    }
+    if options.add_readme {
+        cmd.arg("--add-readme");
+    }
+    inject_shell_env(&mut cmd);
+    if let Some(ref t) = token {
+        cmd.env("GH_TOKEN", t);
+    }
+
+    let output = cmd.output().map_err(|e| format!("Failed to run gh: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!("Failed to create repository: {}", stderr));
+    }
+
+    // Clone the newly created repo
+    let clone_url = format!("git@github.com:{}.git", full_name);
+    clone_and_register(
+        &clone_url,
+        &options.name,
+        None,
+        &profile,
+        &token,
+        state,
+    )
 }
 
 /// Check which connected GH profile has access to the repo at `path`.

--- a/src-tauri/src/commands/helpers.rs
+++ b/src-tauri/src/commands/helpers.rs
@@ -45,10 +45,15 @@ pub fn detect_default_branch(repo_path: &Path) -> Result<String, String> {
         .map_err(|e| format!("Failed to run git: {}", e))?;
 
     if output.status.success() {
-        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+        let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        // Empty repos or detached HEAD return empty string or "HEAD"
+        if !branch.is_empty() && branch != "HEAD" {
+            return Ok(branch);
+        }
     }
 
-    Err("Could not detect default branch".into())
+    // Final fallback for empty repos (no commits yet)
+    Ok("main".to_string())
 }
 
 pub fn repo_display_name(repo_path: &Path) -> String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ pub fn run() {
             commands::github::cancel_gh_auth_login,
             commands::github::list_gh_repos,
             commands::github::clone_repo,
+            commands::github::create_gh_repo,
             commands::github::check_repo_gh_access,
             commands::github::get_pr_status,
             commands::github::get_pr_template,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -132,6 +132,20 @@ export async function cloneRepo(
   });
 }
 
+export interface CreateRepoOptions {
+  name: string;
+  private: boolean;
+  description: string | null;
+  add_readme: boolean;
+}
+
+export async function createGhRepo(
+  options: CreateRepoOptions,
+  profile: string,
+): Promise<RepoDetail> {
+  return invoke<RepoDetail>("create_gh_repo", { options, profile });
+}
+
 export async function checkRepoGhAccess(
   path: string,
   profiles: string[],

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
     cancelGhAuthLogin,
     listGhRepos,
     cloneRepo,
+    createGhRepo,
     setRepoProfile,
     checkRepoGhAccess,
     createStagingWorkspace,
@@ -215,6 +216,12 @@
   let ghAuthInProgress = $state(false);
   let ghAuthCode = $state<string | null>(null);
   let ghSearchTriggered = $state(false);
+  let showCreateForm = $state(false);
+  let createName = $state("");
+  let createPrivate = $state(true);
+  let createDescription = $state("");
+  let createReadme = $state(true);
+  let creating = $state(false);
 
   let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -344,6 +351,33 @@
       addToast(String(e));
     } finally {
       cloning = false;
+    }
+  }
+
+  async function handleCreateRepo() {
+    if (!selectedProfile || !createName.trim()) return;
+    creating = true;
+    try {
+      const result = await createGhRepo(
+        {
+          name: createName.trim(),
+          private: createPrivate,
+          description: createDescription.trim() || null,
+          add_readme: createReadme,
+        },
+        selectedProfile,
+      );
+      if (!repos.find((r) => r.id === result.id)) {
+        repos = [...repos, result];
+      }
+      showCreateForm = false;
+      createName = "";
+      createDescription = "";
+      await selectRepo(result);
+    } catch (e) {
+      addToast(String(e));
+    } finally {
+      creating = false;
     }
   }
 
@@ -1906,11 +1940,64 @@
           {/if}
         </div>
 
-        {#if cloning}
+        {#if cloning || creating}
           <div class="gh-loading">
             <div class="spinner"></div>
-            <span>Cloning repository...</span>
+            <span>{creating ? "Creating repository..." : "Cloning repository..."}</span>
           </div>
+        {:else if selectedProfile && repoSearch.trim() && /^[a-zA-Z0-9._-]+$/.test(repoSearch.trim())}
+          {#if !showCreateForm}
+            <button
+              class="open-repo-btn secondary"
+              onclick={() => { createName = repoSearch.trim(); showCreateForm = true; }}
+            >
+              Create "{repoSearch.trim()}" on GitHub
+            </button>
+          {:else}
+            <div class="create-repo-form">
+              <input
+                type="text"
+                class="create-input"
+                placeholder="Repository name"
+                bind:value={createName}
+              />
+              <input
+                type="text"
+                class="create-input"
+                placeholder="Description (optional)"
+                bind:value={createDescription}
+              />
+              <div class="create-options">
+                <div class="visibility-toggle">
+                  <button
+                    class="vis-btn"
+                    class:selected={createPrivate}
+                    onclick={() => (createPrivate = true)}
+                  >Private</button>
+                  <button
+                    class="vis-btn"
+                    class:selected={!createPrivate}
+                    onclick={() => (createPrivate = false)}
+                  >Public</button>
+                </div>
+                <label class="readme-check">
+                  <input type="checkbox" bind:checked={createReadme} />
+                  Add README
+                </label>
+              </div>
+              <div class="create-actions">
+                <button
+                  class="open-repo-btn"
+                  disabled={!createName.trim() || creating}
+                  onclick={handleCreateRepo}
+                >Create & Open</button>
+                <button
+                  class="open-repo-btn secondary"
+                  onclick={() => (showCreateForm = false)}
+                >Cancel</button>
+              </div>
+            </div>
+          {/if}
         {/if}
 
         {#if selectedProfile}
@@ -2544,6 +2631,94 @@
 
   .open-repo-btn.secondary:hover {
     background: var(--bg-hover);
+  }
+
+  .create-repo-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    background: var(--bg-elevated);
+  }
+
+  .create-input {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-family: inherit;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .create-input:focus {
+    border-color: var(--accent);
+  }
+
+  .create-options {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .visibility-toggle {
+    display: flex;
+    gap: 0;
+  }
+
+  .vis-btn {
+    padding: 0.3rem 0.7rem;
+    font-size: 0.78rem;
+    font-family: inherit;
+    font-weight: 500;
+    border: 1px solid var(--border);
+    background: var(--bg-base);
+    color: var(--text-dim);
+    cursor: pointer;
+  }
+
+  .vis-btn:first-child {
+    border-radius: 5px 0 0 5px;
+  }
+
+  .vis-btn:last-child {
+    border-radius: 0 5px 5px 0;
+    border-left: none;
+  }
+
+  .vis-btn.selected {
+    background: var(--accent);
+    color: var(--bg-base);
+    border-color: var(--accent);
+  }
+
+  .vis-btn.selected + .vis-btn {
+    border-left: none;
+  }
+
+  .readme-check {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .readme-check input[type="checkbox"] {
+    accent-color: var(--accent);
+  }
+
+  .create-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
   }
 
   /* ── App layout ──────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Adds a "Create {name} on GitHub" flow to the home screen — when searching for a repo name that doesn't exist, users can create it inline with name, visibility, description, and README options
- New `create_gh_repo` Rust command runs `gh repo create`, then clones and registers the repo automatically
- Refactored `clone_repo` into a shared `clone_and_register` helper to avoid duplication
- Hardened `detect_default_branch` with a `"main"` fallback for empty repos

## Test plan
- [ ] Search for a non-existent repo name, verify "Create on GitHub" button appears
- [ ] Create a private repo with README, verify it clones and opens in the app
- [ ] Create a public repo, verify visibility on GitHub
- [ ] Try a duplicate repo name, verify error toast
- [ ] Verify existing clone flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)