### PR TITLE
fix: add OS-style z-index focus ordering for review and chat panels

### DIFF
--- a/src/lib/components/ReviewPill.svelte
+++ b/src/lib/components/ReviewPill.svelte
@@ -93,10 +93,6 @@
 
 <style>
   .review-pill {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    z-index: 10;
     background: var(--bg-card);
     border: 1px solid var(--border-light);
     border-radius: 20px;

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -118,6 +118,9 @@
   let hasRunScript = $derived(!!repoSettings?.run_script?.trim());
 
   // ── Terminal pane ──────────────────────────────────────────────
+  // ── Floating panel focus (OS-style z-ordering) ──────────────────
+  let focusedPanel = $state<"review" | "chat">("chat");
+
   let terminalPaneWidth = $state(400);
   const TERMINAL_PANE_MIN = 200;
   const TERMINAL_PANE_MAX = 800;
@@ -305,14 +308,21 @@
 
       <!-- Review pill: floats top-right over left pane -->
       {#if selectedWsId && reviewByWorkspace.has(selectedWsId)}
-        <ReviewPill
-          state={reviewByWorkspace.get(selectedWsId)!}
-          onCancel={() => onReviewCancel(selectedWsId!)}
-          onSendToChat={(markdown) => {
-            onChatExpandedChange(true);
-            onReviewSendToChat(selectedWsId!, markdown);
-          }}
-        />
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="floating-panel-wrapper review-pos"
+          class:panel-focused={focusedPanel === "review"}
+          onmousedown={() => { focusedPanel = "review"; }}
+        >
+          <ReviewPill
+            state={reviewByWorkspace.get(selectedWsId)!}
+            onCancel={() => onReviewCancel(selectedWsId!)}
+            onSendToChat={(markdown) => {
+              onChatExpandedChange(true);
+              onReviewSendToChat(selectedWsId!, markdown);
+            }}
+          />
+        </div>
       {/if}
 
       <!-- Chat overlay: floating panel, per-workspace, always mounted -->
@@ -321,7 +331,8 @@
         {@const isAgentRunning = ws.status === "running"}
         {#if isActive}
           {#if chatExpanded}
-            <div class="chat-overlay">
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div class="chat-overlay" class:panel-focused={focusedPanel === "chat"} onmousedown={() => { focusedPanel = "chat"; }}>
               <div class="chat-overlay-header">
                 <span class="chat-overlay-title">
                   <MessageSquare size={13} strokeWidth={2} />
@@ -358,7 +369,7 @@
             <!-- Collapsed pill -->
             <button
               class="chat-pill"
-              onclick={() => onChatExpandedChange(true)}
+              onclick={() => { focusedPanel = "chat"; onChatExpandedChange(true); }}
               title="Open chat"
             >
               {#if isAgentRunning}
@@ -796,6 +807,22 @@
     z-index: 1;
   }
 
+  /* ── Floating panel focus (OS-style z-ordering) ── */
+
+  .floating-panel-wrapper {
+    position: absolute;
+    z-index: 10;
+  }
+
+  .floating-panel-wrapper.panel-focused {
+    z-index: 11;
+  }
+
+  .floating-panel-wrapper.review-pos {
+    top: 12px;
+    right: 12px;
+  }
+
   /* ── Chat overlay (floating) ───────────────────── */
 
   .chat-overlay {
@@ -814,6 +841,10 @@
     border-radius: 12px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
     overflow: hidden;
+  }
+
+  .chat-overlay.panel-focused {
+    z-index: 11;
   }
 
   .chat-overlay-header {


### PR DESCRIPTION
## Summary
- Clicking the Review or Chat floating panel brings it to the front (higher z-index), like OS window focus
- Adds `focusedPanel` state in WorkspacePanel that toggles between `"review"` and `"chat"` on mousedown
- Moves ReviewPill positioning to a parent wrapper so z-index can be controlled from WorkspacePanel

## Test plan
- [ ] Open a workspace with both Review and Chat panels visible
- [ ] Click Review panel → it should appear above Chat
- [ ] Click Chat panel → it should appear above Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)