### PR TITLE
feat: add delete button to workspace kanban cards

### DIFF
--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -151,6 +151,7 @@
         isReviewing={reviewingWsIds.has(ws.id)}
         isCreating={ws.id === creatingWsId}
         onClick={() => { detailWs = ws; }}
+        onRemove={() => onRemoveWorkspace(ws.id)}
       />
     {/each}
     {#if inProgress.length === 0}
@@ -167,6 +168,7 @@
         changeCounts={changeCounts.get(ws.id)}
         isReviewing={reviewingWsIds.has(ws.id)}
         onClick={() => { detailWs = ws; }}
+        onRemove={() => onRemoveWorkspace(ws.id)}
       />
     {/each}
     {#if review.length === 0}
@@ -182,6 +184,7 @@
         prStatus={prStatusMap.get(ws.id)}
         changeCounts={changeCounts.get(ws.id)}
         onClick={() => { detailWs = ws; }}
+        onRemove={() => onRemoveWorkspace(ws.id)}
       />
     {/each}
     {#if done.length === 0}

--- a/src/lib/components/KanbanCard.svelte
+++ b/src/lib/components/KanbanCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { WorkspaceInfo, PrStatus } from "$lib/ipc";
   import { convertFileSrc } from "@tauri-apps/api/core";
-  import { Play, X, Pencil, Lightbulb, BookOpen, CircleCheck, Circle } from "lucide-svelte";
+  import { Play, X, Trash2, Pencil, Lightbulb, BookOpen, CircleCheck, Circle } from "lucide-svelte";
 
   interface Props {
     type: "todo" | "workspace";
@@ -129,6 +129,11 @@
       <span class="card-name" class:has-title={!!workspace.task_title}>{workspace.task_title ?? workspace.name}</span>
       {#if workspace.status === "running" && !isReviewing}
         <span class="card-elapsed">{elapsed}</span>
+      {/if}
+      {#if onRemove}
+        <button class="ws-remove-btn" onclick={(e) => { e.stopPropagation(); onRemove(); }} title="Remove workspace">
+          <Trash2 size={11} />
+        </button>
       {/if}
     </div>
     {#if workspace.task_description}
@@ -323,6 +328,29 @@
   }
 
   .remove-btn:hover {
+    color: var(--diff-del);
+    background: var(--bg-hover);
+  }
+
+  .ws-remove-btn {
+    display: flex;
+    align-items: center;
+    padding: 0.2rem;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.15s, background 0.15s;
+  }
+
+  .ws-card:hover .ws-remove-btn {
+    opacity: 1;
+  }
+
+  .ws-remove-btn:hover {
     color: var(--diff-del);
     background: var(--bg-hover);
   }


### PR DESCRIPTION
## Summary
- Adds a trash icon button to workspace cards (In Progress, Review, Done columns) that appears on hover
- Clicking the button triggers the existing workspace removal flow with a confirmation dialog via `@tauri-apps/plugin-dialog`
- Todo cards are unaffected — they already have their own remove button

## Test plan
- [ ] Hover over a workspace card in In Progress/Review/Done — trash icon should fade in
- [ ] Click the trash icon — confirmation dialog should appear warning about worktree deletion
- [ ] Confirm removal — workspace and worktree should be deleted
- [ ] Cancel removal — nothing should happen
- [ ] Click elsewhere on the card — should open detail overlay, not trigger delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)