### PR TITLE
feat: cmd+click kanban cards to open workspace directly

### DIFF
--- a/src/lib/components/CardDetailOverlay.svelte
+++ b/src/lib/components/CardDetailOverlay.svelte
@@ -144,6 +144,7 @@
     </div>
 
     <div class="dialog-footer">
+      <span class="shortcut-hint">Tip: <kbd>&#8984;</kbd>+click card to open directly</span>
       <button class="go-btn" onclick={onGoToWorkspace}>
         Go to workspace
         <ArrowRight size={14} />
@@ -354,7 +355,25 @@
   .dialog-footer {
     padding: 0 0.85rem 0.75rem;
     display: flex;
+    align-items: center;
     justify-content: flex-end;
+    gap: 0.6rem;
+  }
+
+  .shortcut-hint {
+    font-size: 0.68rem;
+    color: var(--text-dim);
+    opacity: 0.6;
+    margin-right: auto;
+  }
+
+  .shortcut-hint kbd {
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    padding: 0.08rem 0.25rem;
+    background: color-mix(in srgb, var(--border) 50%, transparent);
+    border: 0.5px solid var(--border);
+    border-radius: 3px;
   }
 
   .go-btn {

--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -150,7 +150,7 @@
         changeCounts={changeCounts.get(ws.id)}
         isReviewing={reviewingWsIds.has(ws.id)}
         isCreating={ws.id === creatingWsId}
-        onClick={() => { detailWs = ws; }}
+        onClick={(e) => { e.metaKey ? onCardClick(ws.id) : detailWs = ws; }}
         onRemove={() => onRemoveWorkspace(ws.id)}
       />
     {/each}
@@ -167,7 +167,7 @@
         prStatus={prStatusMap.get(ws.id)}
         changeCounts={changeCounts.get(ws.id)}
         isReviewing={reviewingWsIds.has(ws.id)}
-        onClick={() => { detailWs = ws; }}
+        onClick={(e) => { e.metaKey ? onCardClick(ws.id) : detailWs = ws; }}
         onRemove={() => onRemoveWorkspace(ws.id)}
       />
     {/each}
@@ -183,7 +183,7 @@
         workspace={ws}
         prStatus={prStatusMap.get(ws.id)}
         changeCounts={changeCounts.get(ws.id)}
-        onClick={() => { detailWs = ws; }}
+        onClick={(e) => { e.metaKey ? onCardClick(ws.id) : detailWs = ws; }}
         onRemove={() => onRemoveWorkspace(ws.id)}
       />
     {/each}

--- a/src/lib/components/KanbanCard.svelte
+++ b/src/lib/components/KanbanCard.svelte
@@ -21,7 +21,7 @@
     isReviewing?: boolean;
     isCreating?: boolean;
     // Common
-    onClick?: () => void;
+    onClick?: (e: MouseEvent) => void;
     onAction?: () => void;
     onEdit?: () => void;
     onRemove?: () => void;
@@ -118,7 +118,7 @@
 {:else if workspace}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="card ws-card" onclick={onClick}>
+  <div class="card ws-card" onclick={(e) => onClick?.(e)}>
     <div class="card-top" class:has-title={!!workspace.task_title}>
       <span
         class="ws-dot"


### PR DESCRIPTION
## Summary
- Cmd+click on workspace kanban cards now navigates directly to the workspace, bypassing the detail overlay
- Regular click still opens the read-only detail overlay as before
- Adds a subtle "Tip: ⌘+click card to open directly" hint in the overlay footer for discoverability

## Test plan
- [ ] Cmd+click a workspace card in In Progress, Review, and Done columns — should navigate to workspace
- [ ] Regular click still opens the detail overlay
- [ ] Verify the hint text renders correctly in the overlay footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)