### PR TITLE
feat: add draggable and resizable floating panels

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,5 +1,399 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 
+// ── Draggable action ─────────────────────────────────────────────────
+
+export interface DragOffset {
+  x: number;
+  y: number;
+}
+
+export interface DraggableOptions {
+  /** CSS selector for the drag handle within the node. If omitted, the whole node is the handle. */
+  handle?: string;
+  /** Current offset — pass stored state so position survives re-mounts. */
+  offset?: DragOffset;
+  /** Called on drag end with the new offset. Store it in parent state. */
+  onDrag?: (offset: DragOffset) => void;
+}
+
+/**
+ * Svelte action: makes an absolutely-positioned element draggable via pointer events.
+ * Uses CSS `transform: translate()` on top of existing positioning.
+ * Hard-clamps the entire element within its offset parent (with 8px edge padding).
+ * Re-clamps on parent resize so panels can never end up outside the visible area.
+ */
+export function draggable(node: HTMLElement, options: DraggableOptions = {}) {
+  let offsetX = options.offset?.x ?? 0;
+  let offsetY = options.offset?.y ?? 0;
+  let startX = 0;
+  let startY = 0;
+  let dragging = false;
+  let didMove = false;
+
+  // Cached measurements from drag start (avoid per-frame reflow)
+  let baseLeft = 0;
+  let baseTop = 0;
+  let nodeW = 0;
+  let nodeH = 0;
+  let parentW = 0;
+  let parentH = 0;
+
+  const EDGE_PAD = 8; // min distance from parent edges
+
+  // Apply initial offset
+  applyTransform();
+
+  let handle = resolveHandle();
+  if (handle) handle.style.cursor = "grab";
+
+  function resolveHandle(): HTMLElement {
+    if (options.handle) {
+      return (node.querySelector(options.handle) as HTMLElement) ?? node;
+    }
+    return node;
+  }
+
+  function applyTransform() {
+    node.style.transform =
+      offsetX || offsetY ? `translate(${offsetX}px, ${offsetY}px)` : "";
+  }
+
+  /** Clamp offset so the full node stays within its offset parent (with padding). */
+  function clamp(newX: number, newY: number): [number, number] {
+    const left = baseLeft + newX;
+    const top = baseTop + newY;
+
+    // Left/right: keep entire width inside parent
+    if (left < EDGE_PAD) newX = EDGE_PAD - baseLeft;
+    else if (left + nodeW > parentW - EDGE_PAD)
+      newX = parentW - EDGE_PAD - nodeW - baseLeft;
+
+    // Top/bottom: keep entire height inside parent
+    if (top < EDGE_PAD) newY = EDGE_PAD - baseTop;
+    else if (top + nodeH > parentH - EDGE_PAD)
+      newY = parentH - EDGE_PAD - nodeH - baseTop;
+
+    return [newX, newY];
+  }
+
+  /** Snapshot the node's natural position and parent size. */
+  function measureLayout() {
+    const parentEl = node.offsetParent as HTMLElement;
+    if (!parentEl) return;
+    const nr = node.getBoundingClientRect();
+    const pr = parentEl.getBoundingClientRect();
+    baseLeft = nr.left - pr.left - offsetX;
+    baseTop = nr.top - pr.top - offsetY;
+    nodeW = nr.width;
+    nodeH = nr.height;
+    parentW = pr.width;
+    parentH = pr.height;
+  }
+
+  /** Re-clamp current offset to parent bounds (e.g. after resize). */
+  function reclamp() {
+    measureLayout();
+    const [cx, cy] = clamp(offsetX, offsetY);
+    if (cx !== offsetX || cy !== offsetY) {
+      offsetX = cx;
+      offsetY = cy;
+      applyTransform();
+      options.onDrag?.({ x: offsetX, y: offsetY });
+    }
+  }
+
+  // Watch parent resize so panels can't end up outside after window shrinks
+  let resizeObserver: ResizeObserver | undefined;
+  const parentEl = node.offsetParent as HTMLElement;
+  if (parentEl) {
+    resizeObserver = new ResizeObserver(() => {
+      if (!dragging && (offsetX || offsetY)) reclamp();
+    });
+    resizeObserver.observe(parentEl);
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    // Don't hijack interactive children
+    if (
+      (e.target as HTMLElement).closest(
+        "button, input, textarea, a, select, [contenteditable]",
+      )
+    )
+      return;
+
+    // Resolve handle lazily (may not exist at mount time in conditional blocks)
+    handle = resolveHandle();
+    if (!handle.contains(e.target as Node)) return;
+
+    e.preventDefault();
+    dragging = true;
+    didMove = false;
+    startX = e.clientX - offsetX;
+    startY = e.clientY - offsetY;
+
+    measureLayout();
+
+    handle.setPointerCapture(e.pointerId);
+    handle.style.cursor = "grabbing";
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging) return;
+
+    let newX = e.clientX - startX;
+    let newY = e.clientY - startY;
+
+    [newX, newY] = clamp(newX, newY);
+
+    offsetX = newX;
+    offsetY = newY;
+    didMove = true;
+    applyTransform();
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!dragging) return;
+    dragging = false;
+    handle.style.cursor = "grab";
+    try {
+      handle.releasePointerCapture(e.pointerId);
+    } catch {
+      /* ignore */
+    }
+    if (didMove) {
+      options.onDrag?.({ x: offsetX, y: offsetY });
+    }
+  }
+
+  // Attach to the node (not handle) so we capture even if handle re-renders.
+  // The pointerdown handler checks handle.contains() to gate.
+  node.addEventListener("pointerdown", onPointerDown);
+  node.addEventListener("pointermove", onPointerMove);
+  node.addEventListener("pointerup", onPointerUp);
+
+  return {
+    update(newOptions: DraggableOptions) {
+      options = newOptions;
+      const newX = newOptions.offset?.x ?? 0;
+      const newY = newOptions.offset?.y ?? 0;
+      if (!dragging && (newX !== offsetX || newY !== offsetY)) {
+        offsetX = newX;
+        offsetY = newY;
+        applyTransform();
+      }
+      const newHandle = resolveHandle();
+      if (newHandle !== handle) {
+        if (handle) handle.style.cursor = "";
+        handle = newHandle;
+        handle.style.cursor = "grab";
+      }
+    },
+    destroy() {
+      node.removeEventListener("pointerdown", onPointerDown);
+      node.removeEventListener("pointermove", onPointerMove);
+      node.removeEventListener("pointerup", onPointerUp);
+      resizeObserver?.disconnect();
+      if (handle) handle.style.cursor = "";
+    },
+  };
+}
+
+// ── Resizable action ─────────────────────────────────────────────────
+
+export interface ResizableOptions {
+  minWidth: number;
+  minHeight: number;
+  /** Called once when a resize gesture starts, with the current computed size. */
+  onResizeStart?: (currentSize: { w: number; h: number }) => void;
+  /** Called on every pointer move during resize. posDelta is the total transform
+   *  compensation needed for right/bottom edge resizing (keeps opposite edge fixed). */
+  onResize?: (
+    size: { w: number; h: number },
+    posDelta: { dx: number; dy: number },
+  ) => void;
+  onResizeEnd?: () => void;
+}
+
+type ResizeEdge = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+const RESIZE_CURSORS: Record<ResizeEdge, string> = {
+  n: "ns-resize",
+  s: "ns-resize",
+  e: "ew-resize",
+  w: "ew-resize",
+  ne: "nesw-resize",
+  nw: "nwse-resize",
+  se: "nwse-resize",
+  sw: "nesw-resize",
+};
+
+/**
+ * Svelte action: adds invisible edge/corner resize handles to an element.
+ * Handles all 8 directions. For a bottom-right anchored element, resizing
+ * from the right or bottom edge reports a position delta so the parent can
+ * compensate via transform to keep the opposite edge stationary.
+ * Caps size to parent bounds on window resize.
+ */
+export function resizable(node: HTMLElement, options: ResizableOptions) {
+  const EDGE = 5; // edge handle thickness
+  const CORNER = 10; // corner handle size
+  const PAD = 8; // min gap from parent edges
+  const handleEls: HTMLElement[] = [];
+
+  let active: ResizeEdge | null = null;
+  let startMX = 0;
+  let startMY = 0;
+  let startW = 0;
+  let startH = 0;
+  let maxW = Infinity;
+  let maxH = Infinity;
+
+  function mkHandle(edge: ResizeEdge) {
+    const el = document.createElement("div");
+    const s = el.style;
+    s.position = "absolute";
+    s.zIndex = "2";
+    s.cursor = RESIZE_CURSORS[edge];
+    s.touchAction = "none";
+
+    const isCorner = edge.length === 2;
+    if (isCorner) {
+      s.width = s.height = `${CORNER}px`;
+      if (edge.includes("n")) s.top = "0";
+      if (edge.includes("s")) s.bottom = "0";
+      if (edge.includes("w")) s.left = "0";
+      if (edge.includes("e")) s.right = "0";
+    } else if (edge === "n" || edge === "s") {
+      s[edge === "n" ? "top" : "bottom"] = "0";
+      s.left = `${CORNER}px`;
+      s.right = `${CORNER}px`;
+      s.height = `${EDGE}px`;
+    } else {
+      s[edge === "w" ? "left" : "right"] = "0";
+      s.top = `${CORNER}px`;
+      s.bottom = `${CORNER}px`;
+      s.width = `${EDGE}px`;
+    }
+
+    el.addEventListener("pointerdown", (e) => onDown(e, edge));
+    node.appendChild(el);
+    handleEls.push(el);
+  }
+
+  const ALL_EDGES: ResizeEdge[] = [
+    "n",
+    "s",
+    "e",
+    "w",
+    "ne",
+    "nw",
+    "se",
+    "sw",
+  ];
+  for (const edge of ALL_EDGES) mkHandle(edge);
+
+  function onDown(e: PointerEvent, edge: ResizeEdge) {
+    e.preventDefault();
+    e.stopPropagation();
+    active = edge;
+    startMX = e.clientX;
+    startMY = e.clientY;
+
+    const r = node.getBoundingClientRect();
+    startW = r.width;
+    startH = r.height;
+
+    const p = node.offsetParent as HTMLElement;
+    if (p) {
+      const pr = p.getBoundingClientRect();
+      maxW = pr.width - PAD * 2;
+      maxH = pr.height - PAD * 2;
+    }
+
+    options.onResizeStart?.({ w: Math.round(startW), h: Math.round(startH) });
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }
+
+  function onMove(e: PointerEvent) {
+    if (!active) return;
+    const dX = e.clientX - startMX;
+    const dY = e.clientY - startMY;
+
+    let w = startW;
+    let h = startH;
+    if (active.includes("w")) w = startW - dX;
+    if (active.includes("e")) w = startW + dX;
+    if (active.includes("n")) h = startH - dY;
+    if (active.includes("s")) h = startH + dY;
+
+    w = Math.round(Math.max(options.minWidth, Math.min(maxW, w)));
+    h = Math.round(Math.max(options.minHeight, Math.min(maxH, h)));
+
+    // Position compensation for right/bottom edges (keeps opposite edge fixed)
+    const posDx = active.includes("e") ? w - Math.round(startW) : 0;
+    const posDy = active.includes("s") ? h - Math.round(startH) : 0;
+
+    node.style.width = `${w}px`;
+    node.style.height = `${h}px`;
+    options.onResize?.({ w, h }, { dx: posDx, dy: posDy });
+  }
+
+  function onUp(e: PointerEvent) {
+    if (!active) return;
+    active = null;
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* ignore */
+    }
+    options.onResizeEnd?.();
+  }
+
+  node.addEventListener("pointermove", onMove);
+  node.addEventListener("pointerup", onUp);
+
+  // Cap size when parent shrinks
+  let ro: ResizeObserver | undefined;
+  const parentEl = node.offsetParent as HTMLElement;
+  if (parentEl) {
+    ro = new ResizeObserver(() => {
+      if (active) return;
+      // Only cap if size was explicitly set (user has resized)
+      if (!node.style.width) return;
+      const pr = parentEl.getBoundingClientRect();
+      const mw = pr.width - PAD * 2;
+      const mh = pr.height - PAD * 2;
+      const nr = node.getBoundingClientRect();
+      const cw = Math.round(
+        Math.max(options.minWidth, Math.min(mw, nr.width)),
+      );
+      const ch = Math.round(
+        Math.max(options.minHeight, Math.min(mh, nr.height)),
+      );
+      if (cw < Math.round(nr.width) || ch < Math.round(nr.height)) {
+        node.style.width = `${cw}px`;
+        node.style.height = `${ch}px`;
+        options.onResize?.({ w: cw, h: ch }, { dx: 0, dy: 0 });
+      }
+    });
+    ro.observe(parentEl);
+  }
+
+  return {
+    update(newOpts: ResizableOptions) {
+      options = newOpts;
+    },
+    destroy() {
+      for (const el of handleEls) el.remove();
+      node.removeEventListener("pointermove", onMove);
+      node.removeEventListener("pointerup", onUp);
+      ro?.disconnect();
+    },
+  };
+}
+
+// ── External links action ────────────────────────────────────────────
+
 /** Svelte action: intercepts <a> clicks inside the node and opens them in the system browser. */
 export function externalLinks(node: HTMLElement) {
   function handleClick(e: MouseEvent) {

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -5,7 +5,7 @@
   import type { ReviewState } from "$lib/components/ReviewPill.svelte";
   import type { ChatPanelApi, QueueDisplayItem, PastedImage } from "$lib/chat-utils";
   import type { Mention } from "$lib/components/MentionInput.svelte";
-  import { ExternalLink, Check, Loader, GitPullRequestCreate, GitMerge, ArrowUp, ArrowDown, AlertTriangle, Wrench, Eye, Play, CircleX, MessageSquare, Minus, ChevronUp, Timer } from "lucide-svelte";
+  import { ExternalLink, Check, Loader, GitPullRequestCreate, GitMerge, ArrowUp, ArrowDown, AlertTriangle, Wrench, Eye, Play, CircleX, MessageSquare, Minus, ChevronUp, Timer, RefreshCcw } from "lucide-svelte";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import ChatPanel from "$lib/components/ChatPanel.svelte";
   import DiffViewer from "$lib/components/DiffViewer.svelte";
@@ -13,6 +13,7 @@
   import TerminalView from "$lib/components/Terminal.svelte";
   import ReviewPill from "$lib/components/ReviewPill.svelte";
   import ResizeHandle from "$lib/components/ResizeHandle.svelte";
+  import { draggable, resizable, type DragOffset } from "$lib/actions";
 
   export type PanelTab = "diff" | "files";
 
@@ -117,9 +118,22 @@
   );
   let hasRunScript = $derived(!!repoSettings?.run_script?.trim());
 
-  // ── Terminal pane ──────────────────────────────────────────────
-  // ── Floating panel focus (OS-style z-ordering) ──────────────────
+  // ── Floating panel focus & drag offsets ─────────────────────────
   let focusedPanel = $state<"review" | "chat">("chat");
+  let reviewDragOffset = $state<DragOffset>({ x: 0, y: 0 });
+  let chatDragOffset = $state<DragOffset>({ x: 0, y: 0 });
+  let chatSize = $state<{ w: number; h: number } | null>(null);
+  let resizeStartDrag = { x: 0, y: 0 };
+
+  function onChatResizeStart(size: { w: number; h: number }) {
+    if (!chatSize) chatSize = size;
+    resizeStartDrag = { ...chatDragOffset };
+  }
+
+  function onChatResize(size: { w: number; h: number }, posDelta: { dx: number; dy: number }) {
+    chatSize = size;
+    chatDragOffset = { x: resizeStartDrag.x + posDelta.dx, y: resizeStartDrag.y + posDelta.dy };
+  }
 
   let terminalPaneWidth = $state(400);
   const TERMINAL_PANE_MIN = 200;
@@ -313,6 +327,7 @@
           class="floating-panel-wrapper review-pos"
           class:panel-focused={focusedPanel === "review"}
           onmousedown={() => { focusedPanel = "review"; }}
+          use:draggable={{ offset: reviewDragOffset, onDrag: (o) => { reviewDragOffset = o; } }}
         >
           <ReviewPill
             state={reviewByWorkspace.get(selectedWsId)!}
@@ -332,19 +347,38 @@
         {#if isActive}
           {#if chatExpanded}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div class="chat-overlay" class:panel-focused={focusedPanel === "chat"} onmousedown={() => { focusedPanel = "chat"; }}>
+            <div
+              class="chat-overlay"
+              class:panel-focused={focusedPanel === "chat"}
+              onmousedown={() => { focusedPanel = "chat"; }}
+              use:draggable={{ handle: ".chat-overlay-header", offset: chatDragOffset, onDrag: (o) => { chatDragOffset = o; } }}
+              use:resizable={{ minWidth: 380, minHeight: 280, onResizeStart: onChatResizeStart, onResize: onChatResize }}
+              style:width={chatSize ? `${chatSize.w}px` : undefined}
+              style:height={chatSize ? `${chatSize.h}px` : undefined}
+            >
               <div class="chat-overlay-header">
                 <span class="chat-overlay-title">
                   <MessageSquare size={13} strokeWidth={2} />
                   Chat
                 </span>
-                <button
-                  class="chat-overlay-collapse"
-                  onclick={() => onChatExpandedChange(false)}
-                  title="Collapse chat"
-                >
-                  <Minus size={14} />
-                </button>
+                <div class="chat-overlay-actions">
+                  {#if chatDragOffset.x || chatDragOffset.y || chatSize}
+                    <button
+                      class="chat-overlay-btn"
+                      onclick={() => { chatDragOffset = { x: 0, y: 0 }; chatSize = null; }}
+                      title="Reset position and size"
+                    >
+                      <RefreshCcw size={12} />
+                    </button>
+                  {/if}
+                  <button
+                    class="chat-overlay-btn"
+                    onclick={() => onChatExpandedChange(false)}
+                    title="Collapse chat"
+                  >
+                    <Minus size={14} />
+                  </button>
+                </div>
               </div>
               <div class="chat-overlay-body">
                 <ChatPanel
@@ -371,6 +405,7 @@
               class="chat-pill"
               onclick={() => { focusedPanel = "chat"; onChatExpandedChange(true); }}
               title="Open chat"
+              style={chatDragOffset.x || chatDragOffset.y ? `transform: translate(${chatDragOffset.x}px, ${chatDragOffset.y}px)` : ""}
             >
               {#if isAgentRunning}
                 <Loader size={13} class="status-icon spinning" />
@@ -865,7 +900,13 @@
     color: var(--text-secondary);
   }
 
-  .chat-overlay-collapse {
+  .chat-overlay-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .chat-overlay-btn {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -879,7 +920,7 @@
     cursor: pointer;
   }
 
-  .chat-overlay-collapse:hover {
+  .chat-overlay-btn:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
   }


### PR DESCRIPTION
## Summary
- Add `draggable` and `resizable` Svelte actions to `$lib/actions.ts` using pointer events with hard-clamped bounds
- ReviewPill and ChatPanel overlay are now draggable; ChatPanel is also resizable from all edges/corners
- Position persists across workspace switches; ResizeObserver recalculates bounds on window resize
- Reset button (RefreshCcw icon) in the chat header snaps position and size back to defaults

## Test plan
- [ ] Drag ReviewPill and ChatPanel around, verify they cannot leave the parent bounds
- [ ] Resize ChatPanel from edges and corners, verify min size (380×280) is enforced
- [ ] Shrink the window after dragging/resizing — panels should reclamp automatically
- [ ] Click reset button — panel snaps back to default position and size
- [ ] Switch workspaces — chat position persists, review pill resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)