### PR TITLE
feat: support multiple terminal tabs per workspace

### DIFF
--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -54,10 +54,8 @@ pub async fn create_staging_workspace(
                 let _ = handle.child.kill();
                 let _ = handle.child.wait();
             }
-            // Kill terminal if running
-            if let Some(mut term) = st.terminals.remove(&existing_id) {
-                let _ = term.child.kill();
-            }
+            // Kill all terminals for this workspace
+            super::terminal::kill_workspace_terminals(&mut st.terminals, &existing_id);
 
             let existing_path = st
                 .workspaces
@@ -242,10 +240,8 @@ pub async fn remove_staging_workspace(
             let _ = handle.child.wait();
         }
 
-        // Kill terminal if running
-        if let Some(mut term) = st.terminals.remove(&ws_id) {
-            let _ = term.child.kill();
-        }
+        // Kill all terminals for this workspace
+        super::terminal::kill_workspace_terminals(&mut st.terminals, &ws_id);
 
         (ws_id, worktree_path, repo_path)
     };

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -3,15 +3,41 @@ use std::sync::{Arc, Mutex};
 use tauri::ipc::Channel;
 use tauri::State;
 
+/// Composite key for the terminals HashMap: `{workspace_id}:{terminal_id}`
+fn terminal_key(workspace_id: &str, terminal_id: &str) -> String {
+    format!("{}:{}", workspace_id, terminal_id)
+}
+
+/// Remove and kill all terminals belonging to a workspace.
+/// Call while holding the lock.
+pub fn kill_workspace_terminals(
+    terminals: &mut std::collections::HashMap<String, crate::state::TerminalHandle>,
+    workspace_id: &str,
+) {
+    let prefix = format!("{}:", workspace_id);
+    let keys: Vec<String> = terminals
+        .keys()
+        .filter(|k| k.starts_with(&prefix))
+        .cloned()
+        .collect();
+    for key in keys {
+        if let Some(mut handle) = terminals.remove(&key) {
+            let _ = handle.child.kill();
+        }
+    }
+}
+
 #[tauri::command]
 pub fn open_terminal(
     workspace_id: String,
+    terminal_id: String,
     on_data: Channel<Vec<u8>>,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<(), String> {
+    let key = terminal_key(&workspace_id, &terminal_id);
     let worktree_path = {
         let st = state.lock().map_err(|e| e.to_string())?;
-        if st.terminals.contains_key(&workspace_id) {
+        if st.terminals.contains_key(&key) {
             return Ok(()); // Already open
         }
         let ws = st
@@ -96,7 +122,7 @@ pub fn open_terminal(
     {
         let mut st = state.lock().map_err(|e| e.to_string())?;
         st.terminals.insert(
-            workspace_id.clone(),
+            key.clone(),
             crate::state::TerminalHandle {
                 writer,
                 child,
@@ -106,7 +132,7 @@ pub fn open_terminal(
     }
 
     // Stream PTY output to frontend via Channel
-    let ws_id = workspace_id.clone();
+    let log_key = key.clone();
     std::thread::spawn(move || {
         let mut buf = [0u8; 4096];
         loop {
@@ -118,7 +144,7 @@ pub fn open_terminal(
                 Err(_) => break,
             }
         }
-        tracing::info!("Terminal reader exited for {}", ws_id);
+        tracing::info!("Terminal reader exited for {}", log_key);
     });
 
     Ok(())
@@ -127,13 +153,15 @@ pub fn open_terminal(
 #[tauri::command]
 pub fn write_terminal(
     workspace_id: String,
+    terminal_id: String,
     data: Vec<u8>,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<(), String> {
+    let key = terminal_key(&workspace_id, &terminal_id);
     let mut st = state.lock().map_err(|e| e.to_string())?;
     let handle = st
         .terminals
-        .get_mut(&workspace_id)
+        .get_mut(&key)
         .ok_or("No terminal open for this workspace")?;
 
     std::io::Write::write_all(&mut handle.writer, &data)
@@ -145,14 +173,16 @@ pub fn write_terminal(
 #[tauri::command]
 pub fn resize_terminal(
     workspace_id: String,
+    terminal_id: String,
     rows: u16,
     cols: u16,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<(), String> {
+    let key = terminal_key(&workspace_id, &terminal_id);
     let mut st = state.lock().map_err(|e| e.to_string())?;
     let handle = st
         .terminals
-        .get_mut(&workspace_id)
+        .get_mut(&key)
         .ok_or("No terminal open for this workspace")?;
 
     handle
@@ -171,10 +201,12 @@ pub fn resize_terminal(
 #[tauri::command]
 pub fn close_terminal(
     workspace_id: String,
+    terminal_id: String,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<(), String> {
+    let key = terminal_key(&workspace_id, &terminal_id);
     let mut st = state.lock().map_err(|e| e.to_string())?;
-    if let Some(mut handle) = st.terminals.remove(&workspace_id) {
+    if let Some(mut handle) = st.terminals.remove(&key) {
         let _ = handle.child.kill();
         let _ = handle.child.wait();
     }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -261,10 +261,8 @@ pub async fn remove_workspace(
             let _ = handle.child.wait();
         }
 
-        // Kill terminal if running
-        if let Some(mut term) = st.terminals.remove(&workspace_id) {
-            let _ = term.child.kill();
-        }
+        // Kill all terminals for this workspace
+        super::terminal::kill_workspace_terminals(&mut st.terminals, &workspace_id);
 
         let ws = st
             .workspaces

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -8,10 +8,11 @@
 
   interface Props {
     workspaceId: string;
+    terminalId: string;
     visible?: boolean;
   }
 
-  let { workspaceId, visible = true }: Props = $props();
+  let { workspaceId, terminalId, visible = true }: Props = $props();
 
   let containerEl: HTMLDivElement | undefined = $state();
   let term: Terminal | undefined;
@@ -45,17 +46,17 @@
 
     term.onData((data) => {
       const bytes = Array.from(new TextEncoder().encode(data));
-      writeTerminal(workspaceId, bytes).catch(() => {});
+      writeTerminal(workspaceId, terminalId, bytes).catch(() => {});
     });
 
-    openTerminal(workspaceId, (data: number[]) => {
+    openTerminal(workspaceId, terminalId, (data: number[]) => {
       if (term) {
         term.write(new Uint8Array(data));
       }
     })
       .then(() => {
         if (term) {
-          resizeTerminal(workspaceId, term.rows, term.cols).catch(() => {});
+          resizeTerminal(workspaceId, terminalId, term.rows, term.cols).catch(() => {});
         }
       })
       .catch((e) => {
@@ -94,7 +95,7 @@
           fitDebounceId = undefined;
           if (fitAddon && term) {
             fitAddon.fit();
-            resizeTerminal(workspaceId, term.rows, term.cols).catch(() => {});
+            resizeTerminal(workspaceId, terminalId, term.rows, term.cols).catch(() => {});
           }
         }, 100);
       }

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { SvelteMap } from "svelte/reactivity";
   import type { WorkspaceInfo, RepoSettings, PrStatus, ScriptEvent } from "$lib/ipc";
-  import { runScript } from "$lib/ipc";
+  import { runScript, closeTerminal } from "$lib/ipc";
   import type { ReviewState } from "$lib/components/ReviewPill.svelte";
   import type { ChatPanelApi, QueueDisplayItem, PastedImage } from "$lib/chat-utils";
   import type { Mention } from "$lib/components/MentionInput.svelte";
-  import { ExternalLink, Check, Loader, GitPullRequestCreate, GitMerge, ArrowUp, ArrowDown, AlertTriangle, Wrench, Eye, Play, CircleX, MessageSquare, Minus, ChevronUp, Timer, RefreshCcw } from "lucide-svelte";
+  import { ExternalLink, Check, Loader, GitPullRequestCreate, GitMerge, ArrowUp, ArrowDown, AlertTriangle, Wrench, Eye, Play, CircleX, MessageSquare, Minus, ChevronUp, Timer, RefreshCcw, Plus } from "lucide-svelte";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import ChatPanel from "$lib/components/ChatPanel.svelte";
   import DiffViewer from "$lib/components/DiffViewer.svelte";
@@ -146,6 +146,78 @@
   function handleTerminalResize(delta: number) {
     terminalPaneWidth = Math.min(TERMINAL_PANE_MAX, Math.max(TERMINAL_PANE_MIN, terminalPaneWidth - delta));
   }
+
+  // ── Multi-terminal tab state ──────────────────────────────────────
+
+  interface TerminalTab {
+    id: string;
+    label: string;
+  }
+
+  let terminalTabs = new SvelteMap<string, TerminalTab[]>();
+  let activeTerminalTab = new SvelteMap<string, string>();
+  let terminalCounters = new SvelteMap<string, number>();
+
+  // Ensure every active workspace has at least one terminal tab
+  $effect(() => {
+    for (const ws of activeWorkspaces) {
+      if (!terminalTabs.has(ws.id)) {
+        const id = crypto.randomUUID();
+        terminalTabs.set(ws.id, [{ id, label: "Terminal 1" }]);
+        activeTerminalTab.set(ws.id, id);
+        terminalCounters.set(ws.id, 1);
+      }
+    }
+  });
+
+  // Clean up stale entries when workspaces are removed
+  $effect(() => {
+    const wsIds = new Set(activeWorkspaces.map((ws) => ws.id));
+    for (const id of terminalTabs.keys()) {
+      if (!wsIds.has(id)) {
+        terminalTabs.delete(id);
+        activeTerminalTab.delete(id);
+        terminalCounters.delete(id);
+      }
+    }
+  });
+
+  function addTerminalTab(wsId: string) {
+    const count = (terminalCounters.get(wsId) ?? 0) + 1;
+    terminalCounters.set(wsId, count);
+    const id = crypto.randomUUID();
+    const tabs = terminalTabs.get(wsId) ?? [];
+    terminalTabs.set(wsId, [...tabs, { id, label: `Terminal ${count}` }]);
+    activeTerminalTab.set(wsId, id);
+  }
+
+  function removeTerminalTab(wsId: string, tabId: string) {
+    const tabs = terminalTabs.get(wsId);
+    if (!tabs || tabs.length <= 1) return;
+
+    const idx = tabs.findIndex((t) => t.id === tabId);
+    if (idx === -1) return;
+
+    const newTabs = tabs.filter((t) => t.id !== tabId);
+    terminalTabs.set(wsId, newTabs);
+
+    // Close backend PTY
+    closeTerminal(wsId, tabId).catch(() => {});
+
+    // Switch active tab if needed
+    if (activeTerminalTab.get(wsId) === tabId) {
+      const newIdx = Math.min(idx, newTabs.length - 1);
+      activeTerminalTab.set(wsId, newTabs[newIdx].id);
+    }
+  }
+
+  let currentTerminalTabs = $derived(
+    selectedWsId ? terminalTabs.get(selectedWsId) ?? [] : []
+  );
+
+  let currentActiveTermTab = $derived(
+    selectedWsId ? activeTerminalTab.get(selectedWsId) ?? null : null
+  );
 
   function handleRunScript() {
     if (!selectedWs || !repoSettings?.run_script?.trim()) return;
@@ -307,19 +379,45 @@
 
       <!-- Right pane: Terminal -->
       <div class="terminal-pane" style="width: {terminalPaneWidth}px">
-        <div class="pane-tabs">
-          <button class="pane-tab active">Terminal</button>
+        <div class="pane-tabs terminal-tabs">
+          {#each currentTerminalTabs as tab (tab.id)}
+            <button
+              class="pane-tab"
+              class:active={tab.id === currentActiveTermTab}
+              onclick={() => selectedWsId && activeTerminalTab.set(selectedWsId, tab.id)}
+            >
+              {tab.label}
+              {#if currentTerminalTabs.length > 1}
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <span
+                  class="tab-close"
+                  role="button"
+                  tabindex="-1"
+                  onclick={(e) => { e.stopPropagation(); selectedWsId && removeTerminalTab(selectedWsId, tab.id); }}
+                >×</span>
+              {/if}
+            </button>
+          {/each}
+          <button
+            class="term-add-btn"
+            title="New terminal"
+            onclick={() => selectedWsId && addTerminalTab(selectedWsId)}
+          >
+            <Plus size={12} />
+          </button>
         </div>
         <div class="terminal-body">
           {#each activeWorkspaces as ws (ws.id)}
-            {@const isVisible = ws.id === selectedWsId}
-            <div
-              class="ws-terminal-layer"
-              class:visible={isVisible}
-              inert={!isVisible}
-            >
-              <TerminalView workspaceId={ws.id} visible={isVisible} />
-            </div>
+            {#each (terminalTabs.get(ws.id) ?? []) as tab (tab.id)}
+              {@const isVisible = ws.id === selectedWsId && tab.id === activeTerminalTab.get(ws.id)}
+              <div
+                class="ws-terminal-layer"
+                class:visible={isVisible}
+                inert={!isVisible}
+              >
+                <TerminalView workspaceId={ws.id} terminalId={tab.id} visible={isVisible} />
+              </div>
+            {/each}
           {/each}
         </div>
       </div>
@@ -828,6 +926,55 @@
     min-height: 0;
   }
 
+  .terminal-tabs {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+  }
+
+  .terminal-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tab-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    font-size: 11px;
+    line-height: 1;
+    color: var(--text-dim);
+    cursor: pointer;
+    margin-left: 2px;
+    flex-shrink: 0;
+  }
+
+  .tab-close:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  .term-add-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-dim);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .term-add-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
 
   .terminal-body {
     flex: 1;

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -429,30 +429,36 @@ export async function generateCommitMessage(
 
 export async function openTerminal(
   workspaceId: string,
+  terminalId: string,
   onData: (data: number[]) => void,
 ): Promise<void> {
   const channel = new Channel<number[]>();
   channel.onmessage = onData;
-  return invoke("open_terminal", { workspaceId, onData: channel });
+  return invoke("open_terminal", { workspaceId, terminalId, onData: channel });
 }
 
 export async function writeTerminal(
   workspaceId: string,
+  terminalId: string,
   data: number[],
 ): Promise<void> {
-  return invoke("write_terminal", { workspaceId, data });
+  return invoke("write_terminal", { workspaceId, terminalId, data });
 }
 
 export async function resizeTerminal(
   workspaceId: string,
+  terminalId: string,
   rows: number,
   cols: number,
 ): Promise<void> {
-  return invoke("resize_terminal", { workspaceId, rows, cols });
+  return invoke("resize_terminal", { workspaceId, terminalId, rows, cols });
 }
 
-export async function closeTerminal(workspaceId: string): Promise<void> {
-  return invoke("close_terminal", { workspaceId });
+export async function closeTerminal(
+  workspaceId: string,
+  terminalId: string,
+): Promise<void> {
+  return invoke("close_terminal", { workspaceId, terminalId });
 }
 // ── Messages ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds multi-terminal tab support to the terminal pane — each workspace can now have multiple independent terminal sessions
- Terminal tab bar with active tab switching, close buttons (hidden on last tab), and a "+" button to spawn new terminals
- Rust backend uses composite `{workspace_id}:{terminal_id}` keys; workspace removal kills all associated terminals via `kill_workspace_terminals` helper

## Test plan
- [ ] Open a workspace, verify default "Terminal 1" tab works as before
- [ ] Click "+" to add terminals, verify each gets its own PTY session
- [ ] Switch between terminal tabs, verify state is preserved (display toggle, no remount)
- [ ] Close a terminal tab via ×, verify PTY is killed and tab disappears
- [ ] Remove a workspace, verify all its terminals are cleaned up
- [ ] Switch between workspaces, verify each workspace's terminal tabs are independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)