### PR TITLE
fix: restore todo mentions as inline chips when editing tasks

### DIFF
--- a/src/lib/components/MentionInput.svelte
+++ b/src/lib/components/MentionInput.svelte
@@ -15,6 +15,7 @@
     insertMention: (mention: Mention) => void;
     appendMention: (mention: Mention) => void;
     insertText: (text: string) => void;
+    restoreContent: (text: string, mentions: Mention[]) => void;
     focus: () => void;
     submit: () => void;
     getValue: () => MentionInputValue;
@@ -134,9 +135,79 @@
     if (lastNode) placeCursorAfter(lastNode);
   }
 
+  function restoreContent(text: string, mentions: Mention[]) {
+    if (!editorEl) return;
+    editorEl.innerHTML = "";
+
+    // Build segments by finding @displayName tokens in the text and replacing with chips
+    interface Segment {
+      kind: "text" | "mention";
+      value: string;
+      mention?: Mention;
+    }
+
+    const segments: Segment[] = [];
+    let remaining = text;
+
+    // Create a lookup: displayName -> mention (for matching @displayName tokens)
+    // A mention may appear multiple times, so use an array and consume matches
+    const mentionPool = [...mentions];
+
+    while (remaining.length > 0) {
+      let earliestIndex = -1;
+      let earliestMention: Mention | null = null;
+      let matchLength = 0;
+
+      for (const m of mentionPool) {
+        const token = `@${m.displayName}`;
+        const idx = remaining.indexOf(token);
+        if (idx >= 0 && (earliestIndex === -1 || idx < earliestIndex)) {
+          earliestIndex = idx;
+          earliestMention = m;
+          matchLength = token.length;
+        }
+      }
+
+      if (earliestIndex === -1 || !earliestMention) {
+        segments.push({ kind: "text", value: remaining });
+        break;
+      }
+
+      if (earliestIndex > 0) {
+        segments.push({ kind: "text", value: remaining.substring(0, earliestIndex) });
+      }
+
+      segments.push({ kind: "mention", value: "", mention: earliestMention });
+
+      // Remove this match from the pool so each saved mention maps to one chip
+      const poolIdx = mentionPool.indexOf(earliestMention);
+      if (poolIdx >= 0) mentionPool.splice(poolIdx, 1);
+
+      remaining = remaining.substring(earliestIndex + matchLength);
+    }
+
+    // Build the DOM from segments
+    for (const seg of segments) {
+      if (seg.kind === "text") {
+        const parts = seg.value.split("\n");
+        for (let i = 0; i < parts.length; i++) {
+          if (i > 0) {
+            editorEl.appendChild(document.createElement("br"));
+          }
+          if (parts[i]) {
+            editorEl.appendChild(document.createTextNode(parts[i]));
+          }
+        }
+      } else if (seg.mention) {
+        const chip = createMentionChip(seg.mention);
+        editorEl.appendChild(chip);
+      }
+    }
+  }
+
   // Expose API via bindable ref
   $effect(() => {
-    ref = { insertMention, appendMention, insertText, focus, submit: handleSubmit, getValue: serialize };
+    ref = { insertMention, appendMention, insertText, restoreContent, focus, submit: handleSubmit, getValue: serialize };
   });
 
   function serialize(): MentionInputValue {

--- a/src/lib/components/TaskPopover.svelte
+++ b/src/lib/components/TaskPopover.svelte
@@ -67,24 +67,12 @@
     requestAnimationFrame(() => titleRef?.focus());
   });
 
-  // Seed initial description text into MentionInput after mount
+  // Seed initial description + inline mention chips on mount
+  let contentRestored = false;
   $effect(() => {
-    if (mentionInputApi && initialDescription) {
-      // MentionInput is contenteditable — set initial text by calling focus and relying on the DOM
-      // We do this once on mount
-      const el = descWrapperEl?.querySelector(".mention-input") as HTMLDivElement | null;
-      if (el && !el.textContent) {
-        el.textContent = initialDescription;
-      }
-    }
-  });
-
-  // Seed initial mentions as chips
-  $effect(() => {
-    if (mentionInputApi && initialMentions.length > 0) {
-      for (const m of initialMentions) {
-        mentionInputApi.appendMention(m);
-      }
+    if (mentionInputApi && !contentRestored && (initialDescription || initialMentions.length > 0)) {
+      contentRestored = true;
+      mentionInputApi.restoreContent(initialDescription, initialMentions);
     }
   });
 


### PR DESCRIPTION
## Summary
- When editing a saved todo, `@file` mentions appeared as raw text in the description AND as duplicate pills appended at the end
- Root cause: two separate `$effect`s — one setting plain text (including `@displayName` tokens), another appending chips at the end
- Added `restoreContent(text, mentions)` to `MentionInput` that parses `@displayName` tokens and reconstructs the contenteditable DOM with proper inline chips interleaved with text
- Replaced the two broken effects in `TaskPopover` with a single guarded call to `restoreContent`

## Test plan
- [ ] Create a todo with `@file` mentions in the description
- [ ] Save, then edit — mentions should render as inline chips, not raw text + pills at end
- [ ] Verify mentions with surrounding text preserve correct positioning
- [ ] Verify multiline descriptions with mentions restore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)