### PR TITLE
feat: add dark/light/system color mode toggle to appearance settings

### DIFF
--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -6,9 +6,9 @@
     type ContextMeta, type ContextBuildStatus, type AgentEvent,
   } from "$lib/ipc";
   import { onMount } from "svelte";
-  import { ArrowLeft, Terminal, Bot, Palette, BookOpen, Loader2, Pencil, Trash2, ChevronDown } from "lucide-svelte";
+  import { ArrowLeft, Terminal, Bot, Palette, BookOpen, Loader2, Pencil, Trash2, ChevronDown, Sun, Moon, Monitor } from "lucide-svelte";
   import { themeList, getPreviewColors, type ThemeId } from "$lib/themes";
-  import { getThemeId, setTheme } from "$lib/stores/theme.svelte";
+  import { getThemeId, setTheme, getColorMode, setColorMode, type ColorMode } from "$lib/stores/theme.svelte";
   import { getCurrentWindow } from "@tauri-apps/api/window";
 
   interface Props {
@@ -23,6 +23,7 @@
   type Section = "scripts" | "agent" | "knowledge" | "appearance";
   let activeSection = $state<Section>("scripts");
   let currentThemeId = $state<ThemeId>(getThemeId());
+  let currentColorMode = $state<ColorMode>(getColorMode());
   let settings = $state<RepoSettings>({
     setup_script: "",
     run_script: "",
@@ -1068,6 +1069,32 @@
           {/each}
         </div>
       </div>
+
+      <div class="setting-block">
+        <div class="setting-meta">
+          <span class="setting-name">Color mode</span>
+          <span class="setting-desc">Override system dark/light preference</span>
+        </div>
+        <div class="color-mode-picker">
+          {#each ([
+            { mode: "light" as ColorMode, icon: Sun, label: "Light" },
+            { mode: "dark" as ColorMode, icon: Moon, label: "Dark" },
+            { mode: "system" as ColorMode, icon: Monitor, label: "System" },
+          ]) as opt}
+            <button
+              class="color-mode-btn"
+              class:active={currentColorMode === opt.mode}
+              onclick={() => {
+                currentColorMode = opt.mode;
+                setColorMode(opt.mode);
+              }}
+            >
+              <svelte:component this={opt.icon} size={14} />
+              <span>{opt.label}</span>
+            </button>
+          {/each}
+        </div>
+      </div>
     {/if}
   </main>
 
@@ -1459,6 +1486,47 @@
 
   .theme-card.selected .theme-name {
     color: var(--accent);
+  }
+
+  /* ── Color mode picker ─────────── */
+
+  .color-mode-picker {
+    display: flex;
+    gap: 0;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    width: fit-content;
+  }
+
+  .color-mode-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 0.85rem;
+    background: none;
+    border: none;
+    border-right: 1px solid var(--border);
+    color: var(--text-dim);
+    font-family: inherit;
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .color-mode-btn:last-child {
+    border-right: none;
+  }
+
+  .color-mode-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+
+  .color-mode-btn.active {
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 10%, var(--bg-sidebar));
   }
 
   /* ── Knowledge base ──────────────── */

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,15 +1,26 @@
 import { themes, defaultThemeId, type ThemeId, type ThemeDefinition, type TerminalColors, type EditorColors } from "$lib/themes";
 
 const STORAGE_KEY = "korlap-theme";
+const MODE_STORAGE_KEY = "korlap-color-mode";
+
+export type ColorMode = "dark" | "light" | "system";
 
 // ── Reactive state ────────────────────────────────────────
 
 let activeId = $state<ThemeId>(readStoredTheme());
+let colorMode = $state<ColorMode>(readStoredColorMode());
 
 function readStoredTheme(): ThemeId {
   if (typeof localStorage === "undefined") return defaultThemeId;
   const stored = localStorage.getItem(STORAGE_KEY);
   return stored && stored in themes ? (stored as ThemeId) : defaultThemeId;
+}
+
+function readStoredColorMode(): ColorMode {
+  if (typeof localStorage === "undefined") return "system";
+  const stored = localStorage.getItem(MODE_STORAGE_KEY);
+  if (stored === "dark" || stored === "light" || stored === "system") return stored;
+  return "system";
 }
 
 // ── Public API ────────────────────────────────────────────
@@ -25,6 +36,19 @@ export function getTheme(): ThemeDefinition {
 export function setTheme(id: ThemeId): void {
   activeId = id;
   localStorage.setItem(STORAGE_KEY, id);
+  applyCssVars();
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("korlap-theme-change"));
+  }
+}
+
+export function getColorMode(): ColorMode {
+  return colorMode;
+}
+
+export function setColorMode(mode: ColorMode): void {
+  colorMode = mode;
+  localStorage.setItem(MODE_STORAGE_KEY, mode);
   applyCssVars();
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent("korlap-theme-change"));
@@ -51,6 +75,8 @@ export function getEditorColorsLight(): EditorColors {
 // ── CSS application ───────────────────────────────────────
 
 function isDark(): boolean {
+  if (colorMode === "dark") return true;
+  if (colorMode === "light") return false;
   return typeof window === "undefined" || window.matchMedia("(prefers-color-scheme: dark)").matches;
 }
 


### PR DESCRIPTION
## Summary
- Adds a Light / Dark / System segmented toggle to the Appearance section in repo settings
- Color mode preference is persisted to localStorage and respected by `isDark()`, overriding the OS preference when set to dark or light
- "System" (default) preserves existing behavior — follows `prefers-color-scheme`
- Changing mode immediately re-applies CSS vars and dispatches `korlap-theme-change` so terminals and editors update in real time

## Test plan
- [ ] Open repo settings → Appearance, verify the new "Color mode" picker appears below themes
- [ ] Toggle to Dark — UI switches to dark regardless of OS setting
- [ ] Toggle to Light — UI switches to light regardless of OS setting
- [ ] Toggle to System — UI follows OS dark/light preference
- [ ] Reload app — verify selection persists
- [ ] Switch OS appearance while on System — verify UI updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)