### PR TITLE
feat: center settings content and increase max width

### DIFF
--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -489,6 +489,7 @@
   </nav>
 
   <main class="settings-main">
+    <div class="settings-content">
     {#if activeSection === "scripts"}
       <div class="section-header">
         <h1>Scripts</h1>
@@ -1096,6 +1097,7 @@
         </div>
       </div>
     {/if}
+    </div>
   </main>
 
 </div>
@@ -1192,7 +1194,13 @@
     flex: 1;
     padding: 2rem 2.5rem;
     overflow-y: auto;
-    max-width: 580px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .settings-content {
+    width: 100%;
+    max-width: 640px;
   }
 
   .section-header {


### PR DESCRIPTION
## Summary
- Centers the settings page content horizontally within the available space after the sidebar, matching macOS System Settings layout
- Wraps content in a `.settings-content` container with `max-width: 640px` (up from 580px) and uses flexbox centering on `.settings-main`
- Previously, content was left-aligned with all empty space stacking on the right

## Test plan
- [ ] Open settings page and verify content is centered in the space to the right of the nav sidebar
- [ ] Resize window to confirm content stays centered and doesn't overflow on narrow widths
- [ ] Check all four sections (Scripts, Agent, Knowledge, Appearance) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)