### PR TITLE
feat: add "Add & Start" button to task popover

### DIFF
--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -37,6 +37,7 @@
     onCardClick: (wsId: string) => void;
     onSpawnAgent: (todoId: string) => void;
     onNewTodo: (data: TaskData) => void;
+    onAddAndStart: (data: TaskData) => void;
     onEditTodo: (todoId: string, data: TaskData) => void;
     onRemoveTodo: (todoId: string) => void;
     onToggleReady: (todoId: string) => void;
@@ -67,6 +68,7 @@
     onCardClick,
     onSpawnAgent,
     onNewTodo,
+    onAddAndStart,
     onEditTodo,
     onRemoveTodo,
     onToggleReady,
@@ -100,6 +102,11 @@
 
   function handleAddSubmit(data: TaskData) {
     onNewTodo(data);
+    showAddDialog = false;
+  }
+
+  function handleAddAndStartSubmit(data: TaskData) {
+    onAddAndStart(data);
     showAddDialog = false;
   }
 
@@ -223,6 +230,7 @@
     initialThinkingMode={defaultThinkingMode}
     submitLabel="Add"
     onSubmit={handleAddSubmit}
+    onSubmitAndStart={handleAddAndStartSubmit}
     onCancel={() => { showAddDialog = false; }}
   />
 {/if}

--- a/src/lib/components/TaskPopover.svelte
+++ b/src/lib/components/TaskPopover.svelte
@@ -27,6 +27,7 @@
     initialThinkingMode?: boolean;
     submitLabel?: string;
     onSubmit: (data: TaskData) => void;
+    onSubmitAndStart?: (data: TaskData) => void;
     onCancel: () => void;
   }
 
@@ -40,6 +41,7 @@
     initialThinkingMode = false,
     submitLabel = "Add",
     onSubmit,
+    onSubmitAndStart,
     onCancel,
   }: Props = $props();
 
@@ -83,8 +85,8 @@
     mentions.length > 0
   );
 
-  function submit() {
-    if (!canSubmit) return;
+  function buildTaskData(): TaskData | null {
+    if (!canSubmit) return null;
     // Serialize description + inline mentions from MentionInput
     const descValue = mentionInputApi?.getValue() ?? { text: "", mentions: [] };
     // Merge inline mentions with separately-tracked mentions (from SearchModal, etc.)
@@ -94,7 +96,7 @@
         allMentions.push(m);
       }
     }
-    onSubmit({
+    return {
       title: title.trim(),
       description: descValue.text.trim(),
       newImages: [...newImages],
@@ -102,7 +104,18 @@
       mentions: allMentions,
       planMode,
       thinkingMode,
-    });
+    };
+  }
+
+  function submit() {
+    const data = buildTaskData();
+    if (data) onSubmit(data);
+  }
+
+  function submitAndStart() {
+    if (!onSubmitAndStart) return;
+    const data = buildTaskData();
+    if (data) onSubmitAndStart(data);
   }
 
   function handleOverlayKeydown(e: KeyboardEvent) {
@@ -116,7 +129,10 @@
         onCancel();
       }
     }
-    if (e.key === "Enter" && e.metaKey) {
+    if (e.key === "Enter" && e.metaKey && e.shiftKey) {
+      e.preventDefault();
+      submitAndStart();
+    } else if (e.key === "Enter" && e.metaKey) {
       e.preventDefault();
       submit();
     }
@@ -131,7 +147,11 @@
       e.preventDefault();
       onCancel();
     }
-    if (e.key === "Enter" && e.metaKey) {
+    if (e.key === "Enter" && e.metaKey && e.shiftKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      submitAndStart();
+    } else if (e.key === "Enter" && e.metaKey) {
       e.preventDefault();
       e.stopPropagation();
       submit();
@@ -244,8 +264,14 @@
       return;
     }
 
+    // Cmd+Shift+Enter to submit and start
+    if (e.key === "Enter" && e.metaKey && e.shiftKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      submitAndStart();
+    }
     // Cmd+Enter to submit
-    if (e.key === "Enter" && e.metaKey) {
+    else if (e.key === "Enter" && e.metaKey) {
       e.preventDefault();
       e.stopPropagation();
       submit();
@@ -367,10 +393,13 @@
           </button>
         {/if}
         <button class="cancel-btn" onclick={onCancel}>Cancel</button>
+        {#if onSubmitAndStart}
+          <button class="add-start-btn" onclick={submitAndStart} disabled={!canSubmit}>{submitLabel} & Start</button>
+        {/if}
         <button class="submit-btn" onclick={submit} disabled={!canSubmit}>{submitLabel}</button>
       </div>
       </div>
-      <span class="footer-hint">⌘Enter to {submitLabel.toLowerCase()} · {repoId ? "@mention files · " : ""}Paste images</span>
+      <span class="footer-hint">⌘Enter to {submitLabel.toLowerCase()}{onSubmitAndStart ? " · ⌘⇧Enter to start" : ""} · {repoId ? "@mention files · " : ""}Paste images</span>
     </div>
   </div>
 
@@ -649,6 +678,29 @@
   .cancel-btn:hover {
     background: var(--btn-subtle-hover);
     color: var(--text-primary);
+  }
+
+  .add-start-btn {
+    padding: 0.35rem 0.7rem;
+    background: transparent;
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .add-start-btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  .add-start-btn:hover:not(:disabled) {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
   }
 
   .submit-btn {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -780,15 +780,16 @@
     return Promise.all(newImages.map((img) => saveImage(namespace, img.base64, img.extension)));
   }
 
-  async function handleNewTodo(data: { title: string; description: string; newImages: PastedImage[]; existingPaths: string[]; mentions?: Mention[]; planMode?: boolean; thinkingMode?: boolean }) {
-    if (!activeRepo) return;
-    if (!data.title.trim() && data.newImages.length === 0 && data.existingPaths.length === 0) return;
+  async function handleNewTodo(data: { title: string; description: string; newImages: PastedImage[]; existingPaths: string[]; mentions?: Mention[]; planMode?: boolean; thinkingMode?: boolean }): Promise<string | null> {
+    if (!activeRepo) return null;
+    if (!data.title.trim() && data.newImages.length === 0 && data.existingPaths.length === 0) return null;
     try {
       const savedPaths = await saveTodoImages(data.newImages);
       const allPaths = [...data.existingPaths, ...savedPaths];
       const mentionPaths = data.mentions?.map((m) => m.path) ?? [];
+      const todoId = crypto.randomUUID();
       todos.push({
-        id: crypto.randomUUID(),
+        id: todoId,
         repo_id: activeRepo.id,
         title: data.title.trim(),
         description: data.description.trim(),
@@ -800,9 +801,16 @@
       });
       persistTodos();
       if (autopilotEnabled) { await updateDependencies(); reprioritizeTodos(); }
+      return todoId;
     } catch (e) {
       addToast(`Failed to save images: ${e}`);
+      return null;
     }
+  }
+
+  async function handleNewTodoAndStart(data: { title: string; description: string; newImages: PastedImage[]; existingPaths: string[]; mentions?: Mention[]; planMode?: boolean; thinkingMode?: boolean }) {
+    const todoId = await handleNewTodo(data);
+    if (todoId) await handleSpawnFromTodo(todoId);
   }
 
   async function handleEditTodo(todoId: string, data: { title: string; description: string; newImages: PastedImage[]; existingPaths: string[]; mentions?: Mention[]; planMode?: boolean; thinkingMode?: boolean }) {
@@ -2257,6 +2265,7 @@
           onCardClick={handleKanbanCardClick}
           onSpawnAgent={handleSpawnFromTodo}
           onNewTodo={handleNewTodo}
+          onAddAndStart={handleNewTodoAndStart}
           onEditTodo={handleEditTodo}
           onRemoveTodo={handleRemoveTodo}
           onToggleReady={handleToggleReady}


### PR DESCRIPTION
## Summary
- Adds an "Add & Start" button to the task creation popover, placed between Cancel and Add
- Clicking it creates the todo and immediately spawns an agent to work on it
- Keyboard shortcut: ⌘⇧Enter (shown in footer hint)
- Button uses an outlined accent style to stay visually secondary to the primary "Add" button
- Only appears in add mode, not when editing existing tasks

## Test plan
- [ ] Open task creation popover, verify "Add & Start" button appears between Cancel and Add
- [ ] Create a task with "Add & Start" — confirm it creates the todo and immediately starts the agent
- [ ] Create a task with "Add" — confirm it still only adds without starting
- [ ] Test ⌘⇧Enter keyboard shortcut from both title and description fields
- [ ] Edit an existing task — verify "Add & Start" button does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)