### PR TITLE
chore: eliminate all cargo warnings

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,11 @@ grep-matcher = "0.1"
 regex = "1"
 sysinfo = "0.33"
 
+[lints.rust]
+# The `objc` 0.2 crate's sel_impl! macro uses cfg(feature = "cargo-clippy"),
+# which triggers check-cfg warnings. Declare it as expected.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"
 objc = "0.2"

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -40,6 +40,7 @@ pub enum AgentEvent {
     #[serde(rename = "done")]
     Done,
     #[serde(rename = "error")]
+    #[allow(dead_code)]
     Error { message: String },
 }
 
@@ -249,7 +250,7 @@ pub fn send_message(
 ) -> Result<(), String> {
     let plan_mode = plan_mode.unwrap_or(false);
     let thinking_mode = thinking_mode.unwrap_or(false);
-    let (worktree_path, gh_profile, repo_id, ws_branch, repo_path, user_system_prompt, context_dir) = {
+    let (worktree_path, gh_profile, _repo_id, ws_branch, repo_path, user_system_prompt, context_dir) = {
         let st = state.lock().map_err(|e| e.to_string())?;
         if st.agents.contains_key(&workspace_id) {
             return Err("Agent is already processing a message".into());
@@ -447,7 +448,7 @@ pub fn send_message(
                         if !relevant.is_empty() && injected + relevant.len() < max_context_chars {
                             system_prompt.push_str("\n\n## Relevant Context\n\n");
                             system_prompt.push_str(&relevant);
-                            injected += relevant.len();
+                            let _ = relevant.len(); // already last context block
                         }
                     }
                 }

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -2,7 +2,7 @@ use crate::state::AppState;
 use std::sync::{Arc, Mutex};
 use tauri::State;
 
-use super::helpers::{detect_default_branch, git_cmd_with_auth, resolve_gh_token};
+use super::helpers::{git_cmd_with_auth, resolve_gh_token};
 
 // ── Repo branch commands ────────────────────────────────────────────
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -105,12 +105,6 @@ pub fn check_gh_cli() -> Result<GhCliStatus, String> {
     })
 }
 
-#[derive(Clone, serde::Serialize)]
-pub struct GhAuthResult {
-    pub code: String,
-    pub url: String,
-}
-
 #[tauri::command]
 pub async fn gh_auth_login(app_handle: AppHandle) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use tauri::State;
 use uuid::Uuid;
 
-use super::helpers::{detect_default_branch, inject_shell_env, repo_display_name};
+use super::helpers::{detect_default_branch, repo_display_name};
 
 #[derive(Clone, serde::Serialize)]
 pub struct RepoDetail {

--- a/src-tauri/src/traffic.rs
+++ b/src-tauri/src/traffic.rs
@@ -1,6 +1,7 @@
 // macOS traffic light positioning.
 // Adapted from db-atelier's approach: moves the button group superview
 // as a unit, preserving native inter-button spacing.
+#![allow(deprecated, missing_abi)]
 
 use cocoa::appkit::{NSView, NSWindow, NSWindowButton};
 use cocoa::base::id;


### PR DESCRIPTION
## Summary
- Removed unused imports (`detect_default_branch`, `inject_shell_env`) and dead struct `GhAuthResult`
- Suppressed `deprecated`/`missing_abi` warnings from `cocoa` crate usage in `traffic.rs`
- Declared `cargo-clippy` as expected cfg value to silence `objc` macro warnings
- Fixed unused variable (`_repo_id`) and dead assignment (`injected`) in `agent.rs`

## Test plan
- [x] `cargo check` produces zero warnings
- [x] `bun run check` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)