### PR TITLE
feat: display token consumption per workspace in chat panel

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -37,11 +37,42 @@ pub enum AgentEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         thinking: Option<String>,
     },
+    #[serde(rename = "usage")]
+    Usage {
+        input_tokens: u64,
+        output_tokens: u64,
+        /// true = cumulative session total (from result event), replaces previous count
+        /// false = single API call (from assistant event), added to running total
+        cumulative: bool,
+    },
     #[serde(rename = "done")]
     Done,
     #[serde(rename = "error")]
     #[allow(dead_code)]
     Error { message: String },
+}
+
+/// Extract total input and output tokens from a usage JSON object.
+/// Claude Code splits input across input_tokens, cache_creation_input_tokens,
+/// and cache_read_input_tokens — sum all three for the real total.
+fn extract_usage(usage: &serde_json::Value) -> (u64, u64) {
+    let input = usage
+        .get("input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let cache_create = usage
+        .get("cache_creation_input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let cache_read = usage
+        .get("cache_read_input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let output = usage
+        .get("output_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    (input + cache_create + cache_read, output)
 }
 
 fn parse_stream_line(
@@ -160,11 +191,36 @@ fn parse_stream_line(
             if !text.is_empty() || !tool_uses.is_empty() || thinking.is_some() {
                 let _ = on_event.send(AgentEvent::AssistantMessage { text, tool_uses, thinking });
             }
+
+            // Extract per-call token usage from message.usage
+            if let Some(usage) = message.get("usage") {
+                let (input, output) = extract_usage(usage);
+                if input > 0 || output > 0 {
+                    let _ = on_event.send(AgentEvent::Usage {
+                        input_tokens: input,
+                        output_tokens: output,
+                        cumulative: false,
+                    });
+                }
+            }
         }
         "result" => {
             if let Some(sid) = v.get("session_id").and_then(|s| s.as_str()) {
                 *session_id = Some(sid.to_string());
             }
+
+            // Extract cumulative session usage from result event (authoritative)
+            if let Some(usage) = v.get("usage") {
+                let (input, output) = extract_usage(usage);
+                if input > 0 || output > 0 {
+                    let _ = on_event.send(AgentEvent::Usage {
+                        input_tokens: input,
+                        output_tokens: output,
+                        cumulative: true,
+                    });
+                }
+            }
+
             let _ = on_event.send(AgentEvent::Done);
         }
         _ => {}

--- a/src/lib/components/ChatPanel.svelte
+++ b/src/lib/components/ChatPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { messagesByWorkspace, sendingByWorkspace, type Message, type MessageChunk, type MessageMention } from "$lib/stores/messages.svelte";
+  import { messagesByWorkspace, sendingByWorkspace, tokensByWorkspace, type Message, type MessageChunk, type MessageMention } from "$lib/stores/messages.svelte";
   import { searchWorkspaceFiles, suggestReplies, type FileSearchResult } from "$lib/ipc";
   import { Lightbulb, BookOpen, Play, ArrowUp, Square, Loader2, Timer, Settings, Pencil } from "lucide-svelte";
   import { renderMarkdown } from "$lib/markdown";
@@ -49,6 +49,17 @@
   let messagesMap = $derived(messagesByWorkspace.get(workspaceId));
   let messages = $derived(messagesMap ? [...messagesMap.values()] : []);
   let sending = $derived(sendingByWorkspace.get(workspaceId) ?? false);
+
+  // Token consumption for this workspace
+  let tokens = $derived(tokensByWorkspace.get(workspaceId));
+  let totalTokens = $derived(tokens ? tokens.input + tokens.output : 0);
+
+  function formatTokens(n: number): string {
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+    if (n >= 10_000) return (n / 1_000).toFixed(0) + "k";
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + "k";
+    return n.toString();
+  }
 
   // Elapsed timer for "thinking" indicator
   let thinkingStartTime = $state<number | null>(null);
@@ -241,7 +252,7 @@
   // Footer items (file pills, plan actions, suggestions, thinking) rendered
   // as a single extra item at the end of the virtual list so they scroll naturally.
   let hasFooter = $derived(
-    (recentFiles.length > 0 && !sending) || showExecutePlan || sending || suggestedReplies.length > 0,
+    (recentFiles.length > 0 && !sending) || showExecutePlan || sending || suggestedReplies.length > 0 || totalTokens > 0,
   );
   let virtualCount = $derived(visualBlocks.length + (hasFooter ? 1 : 0));
 
@@ -566,6 +577,16 @@
                 <div class="thinking">
                   <Timer size={13} strokeWidth={2} />
                   <span class="thinking-timer">{thinkingElapsed}s</span>
+                  {#if totalTokens > 0}
+                    <span class="token-separator">·</span>
+                    <span class="token-count">{formatTokens(totalTokens)} tokens</span>
+                  {/if}
+                </div>
+              </div>
+            {:else if totalTokens > 0}
+              <div class="assistant-msg">
+                <div class="thinking token-summary">
+                  <span class="token-count">{formatTokens(totalTokens)} tokens</span>
                 </div>
               </div>
             {/if}
@@ -1116,6 +1137,18 @@
 
   .thinking-timer {
     min-width: 4.5ch;
+  }
+
+  .token-separator {
+    opacity: 0.5;
+  }
+
+  .token-count {
+    white-space: nowrap;
+  }
+
+  .token-summary {
+    opacity: 0.5;
   }
 
   @keyframes pulse {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -41,6 +41,7 @@ export interface ToolUseInfo {
 
 export type AgentEvent =
   | { type: "assistant_message"; text: string; tool_uses: ToolUseInfo[]; thinking?: string }
+  | { type: "usage"; input_tokens: number; output_tokens: number; cumulative: boolean }
   | { type: "done" }
   | { type: "error"; message: string };
 

--- a/src/lib/stores/messages.svelte.ts
+++ b/src/lib/stores/messages.svelte.ts
@@ -33,6 +33,35 @@ export interface Message {
 export const messagesByWorkspace = new SvelteMap<string, SvelteMap<string, Message>>();
 export const sendingByWorkspace = new SvelteMap<string, boolean>();
 
+// ── Token usage tracking (cumulative per workspace) ───────────────
+// Two-tier: completedTokens (finalized from result events) + turnTokens (live from assistant events).
+// tokensByWorkspace = completed + turn, recomputed on every update for reactive display.
+const completedTokens = new Map<string, { input: number; output: number }>();
+const turnTokens = new SvelteMap<string, { input: number; output: number }>();
+export const tokensByWorkspace = new SvelteMap<string, { input: number; output: number }>();
+
+function updateTokens(wsId: string) {
+  const c = completedTokens.get(wsId) ?? { input: 0, output: 0 };
+  const t = turnTokens.get(wsId) ?? { input: 0, output: 0 };
+  tokensByWorkspace.set(wsId, { input: c.input + t.input, output: c.output + t.output });
+}
+
+/** Live per-call usage from assistant events — accumulates within current turn. */
+export function addTurnTokens(wsId: string, inputTokens: number, outputTokens: number) {
+  const current = turnTokens.get(wsId) ?? { input: 0, output: 0 };
+  turnTokens.set(wsId, { input: current.input + inputTokens, output: current.output + outputTokens });
+  updateTokens(wsId);
+}
+
+/** Authoritative per-turn total from result event — replaces turn accumulation. */
+export function finalizeTurnTokens(wsId: string, inputTokens: number, outputTokens: number) {
+  const c = completedTokens.get(wsId) ?? { input: 0, output: 0 };
+  completedTokens.set(wsId, { input: c.input + inputTokens, output: c.output + outputTokens });
+  turnTokens.delete(wsId);
+  updateTokens(wsId);
+}
+
+
 export function setSending(wsId: string, value: boolean) {
   sendingByWorkspace.set(wsId, value);
 }
@@ -182,4 +211,7 @@ export function clearWorkspaceData(workspaceId: string) {
   if (pending) clearTimeout(pending);
   pendingSaves.delete(workspaceId);
   messagesByWorkspace.delete(workspaceId);
+  completedTokens.delete(workspaceId);
+  turnTokens.delete(workspaceId);
+  tokensByWorkspace.delete(workspaceId);
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,6 +59,8 @@
     addUserMessage,
     addAssistantMessage,
     addActionMessage,
+    addTurnTokens,
+    finalizeTurnTokens,
     loadPersistedMessages,
     clearWorkspaceData,
     setSending,
@@ -1400,6 +1402,12 @@
           } else if (event.text.trim()) {
             agentTaskByWorkspace.set(wsId, "Thinking...");
           }
+        } else if (event.type === "usage") {
+          if (event.cumulative) {
+            finalizeTurnTokens(wsId, event.input_tokens, event.output_tokens);
+          } else {
+            addTurnTokens(wsId, event.input_tokens, event.output_tokens);
+          }
         } else if (event.type === "done") {
           setSending(wsId, false);
           agentTaskByWorkspace.delete(wsId);
@@ -1852,6 +1860,12 @@
             review.resultMarkdown = event.text.trim();
           }
           reviewByWorkspace.set(wsId, { ...review });
+        } else if (event.type === "usage") {
+          if (event.cumulative) {
+            finalizeTurnTokens(wsId, event.input_tokens, event.output_tokens);
+          } else {
+            addTurnTokens(wsId, event.input_tokens, event.output_tokens);
+          }
         } else if (event.type === "done") {
           review.status = "complete";
           reviewByWorkspace.set(wsId, { ...review });


### PR DESCRIPTION
## Summary
- Parses token usage from Claude's stream-json `assistant` and `result` events in Rust, including cache tokens (`cache_creation_input_tokens` + `cache_read_input_tokens`)
- Two-tier tracking: live per-call accumulation from `assistant` events during a turn, replaced by authoritative totals from `result` events at turn end
- Displays formatted token count (e.g. `15.2k tokens`) next to the timer while agent is running, persists as a dimmed summary after the turn ends
- Accumulates across all turns per workspace session

## Test plan
- [ ] Send a message and verify token count appears next to the timer in real-time
- [ ] After turn ends, verify token count persists and timer disappears
- [ ] Send multiple messages and verify tokens accumulate across turns
- [ ] Switch workspaces and verify each has independent token counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)