### PR TITLE
feat: support multiple named run scripts with stop capability

### DIFF
--- a/src-tauri/src/commands/scripts.rs
+++ b/src-tauri/src/commands/scripts.rs
@@ -1,4 +1,5 @@
 use crate::state::AppState;
+use std::os::unix::process::CommandExt;
 use std::sync::{Arc, Mutex};
 use tauri::ipc::Channel;
 use tauri::State;
@@ -37,13 +38,26 @@ pub fn run_script(
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
     inject_shell_env(&mut cmd);
+    // Create a new process group so we can kill the entire tree.
+    cmd.process_group(0);
 
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to run script: {}", e))?;
 
+    let pid = child.id();
+
+    // Store PID so stop_script can kill it
+    {
+        let mut st = state.lock().map_err(|e| e.to_string())?;
+        st.script_pids.insert(workspace_id.clone(), pid);
+    }
+
     let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
     let stderr = child.stderr.take().ok_or("Failed to capture stderr")?;
+
+    let state_clone = state.inner().clone();
+    let ws_id = workspace_id.clone();
 
     // Read stdout and stderr concurrently to avoid pipe buffer deadlock.
     // If the child fills the stderr pipe buffer (~64KB) while we're blocked
@@ -82,7 +96,38 @@ pub fn run_script(
         let _ = stderr_handle.join();
         let code = child.wait().ok().and_then(|s| s.code());
         let _ = on_event.send(ScriptEvent::Exit { code });
+
+        // Clean up stored PID
+        if let Ok(mut st) = state_clone.lock() {
+            st.script_pids.remove(&ws_id);
+        }
     });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn stop_script(
+    workspace_id: String,
+    state: State<'_, Arc<Mutex<AppState>>>,
+) -> Result<(), String> {
+    let pid = {
+        let st = state.lock().map_err(|e| e.to_string())?;
+        st.script_pids.get(&workspace_id).copied()
+    };
+
+    let pid = pid.ok_or("No running script for this workspace")?;
+
+    // Kill the entire process group so child processes are also terminated.
+    // Negative PID targets the process group. SIGTERM (15) allows graceful shutdown.
+    let status = std::process::Command::new("kill")
+        .args(["--", &format!("-{}", pid)])
+        .status()
+        .map_err(|e| format!("Failed to kill script: {}", e))?;
+
+    if !status.success() {
+        return Err("Failed to terminate script process group".to_string());
+    }
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
                 terminals: HashMap::new(),
                 context_meta: HashMap::new(),
                 context_agents: HashMap::new(),
+                script_pids: HashMap::new(),
             };
 
             if let Err(e) = app_state.load() {
@@ -122,6 +123,7 @@ pub fn run() {
             commands::agent::interpret_autopilot_command,
             // scripts
             commands::scripts::run_script,
+            commands::scripts::stop_script,
             // terminal
             commands::terminal::open_terminal,
             commands::terminal::write_terminal,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -41,11 +41,22 @@ pub struct AgentHandle {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NamedScript {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RepoSettings {
     #[serde(default)]
     pub setup_script: String,
+    /// Deprecated: migrated to run_scripts on load. Kept for backward compat deserialization.
+    #[serde(default, skip_serializing)]
+    run_script: String,
     #[serde(default)]
-    pub run_script: String,
+    pub run_scripts: Vec<NamedScript>,
     #[serde(default, alias = "archive_script")]
     pub remove_script: String,
     #[serde(default)]
@@ -58,6 +69,18 @@ pub struct RepoSettings {
     pub default_plan: bool,
     #[serde(default)]
     pub system_prompt: String,
+}
+
+impl RepoSettings {
+    /// Migrate legacy single `run_script` field into `run_scripts` vec.
+    pub fn migrate(&mut self) {
+        if self.run_scripts.is_empty() && !self.run_script.is_empty() {
+            self.run_scripts.push(NamedScript {
+                name: "Run".to_string(),
+                command: std::mem::take(&mut self.run_script),
+            });
+        }
+    }
 }
 
 pub struct TerminalHandle {
@@ -123,6 +146,8 @@ pub struct AppState {
     pub terminals: HashMap<String, TerminalHandle>,
     pub context_meta: HashMap<String, ContextMeta>,
     pub context_agents: HashMap<String, AgentHandle>,
+    /// PID of currently running script per workspace, for stop_script.
+    pub script_pids: HashMap<String, u32>,
 }
 
 impl AppState {
@@ -198,9 +223,12 @@ impl AppState {
         let settings_path = self.data_dir.join("repo_settings.json");
         if settings_path.exists() {
             if let Ok(data) = std::fs::read_to_string(&settings_path) {
-                if let Ok(settings) =
+                if let Ok(mut settings) =
                     serde_json::from_str::<HashMap<String, RepoSettings>>(&data)
                 {
+                    for s in settings.values_mut() {
+                        s.migrate();
+                    }
                     self.repo_settings.extend(settings);
                 }
             }

--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    getRepoSettings, saveRepoSettings, type RepoSettings,
+    getRepoSettings, saveRepoSettings, type RepoSettings, type NamedScript,
     getContextMeta, saveContextScope, buildKnowledgeBase, stopContextBuild,
     readContextFile, writeContextFile, draftContradictionResolution, resolveContradiction, updateKnowledgeBaseIncremental,
     type ContextMeta, type ContextBuildStatus, type AgentEvent,
@@ -26,7 +26,7 @@
   let currentColorMode = $state<ColorMode>(getColorMode());
   let settings = $state<RepoSettings>({
     setup_script: "",
-    run_script: "",
+    run_scripts: [],
     remove_script: "",
     pr_message: "",
     review_message: "",
@@ -34,6 +34,16 @@
     default_plan: false,
     system_prompt: "",
   });
+
+  function addRunScript() {
+    settings.run_scripts = [...settings.run_scripts, { name: "", command: "" }];
+    scheduleAutosave();
+  }
+
+  function removeRunScript(index: number) {
+    settings.run_scripts = settings.run_scripts.filter((_, i) => i !== index);
+    scheduleAutosave();
+  }
   let saveStatus = $state<"idle" | "saving" | "saved">("idle");
   let saveTimeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -517,19 +527,43 @@
 
       <div class="setting-block">
         <div class="setting-meta">
-          <span class="setting-name">Run</span>
-          <span class="setting-desc">Starts when you click ▶ in the Scripts tab</span>
+          <span class="setting-name">Run Scripts</span>
+          <span class="setting-desc">Available from ▶ button in workspace. First script is the default.</span>
         </div>
-        <div class="script-field">
-          <span class="script-prompt">$</span>
-          <textarea
-            bind:value={settings.run_script}
-            oninput={scheduleAutosave}
-            placeholder="bun run dev"
-            rows="2"
-            spellcheck="false"
-          ></textarea>
-        </div>
+        {#each settings.run_scripts as script, i}
+          <div class="run-script-entry" class:is-default={i === 0}>
+            <div class="run-script-entry-header">
+              {#if i === 0}
+                <span class="default-badge">Default</span>
+              {/if}
+              <input
+                class="run-script-name-input"
+                bind:value={script.name}
+                oninput={scheduleAutosave}
+                placeholder="Script name"
+                spellcheck="false"
+              />
+              <button
+                class="run-script-delete"
+                onclick={() => removeRunScript(i)}
+                title="Remove script"
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+            <div class="script-field">
+              <span class="script-prompt">$</span>
+              <textarea
+                bind:value={script.command}
+                oninput={scheduleAutosave}
+                placeholder="bun run dev"
+                rows="2"
+                spellcheck="false"
+              ></textarea>
+            </div>
+          </div>
+        {/each}
+        <button class="add-script-btn" onclick={addRunScript}>+ Add script</button>
       </div>
 
       <div class="setting-block">
@@ -1290,6 +1324,98 @@
 
   .script-field:focus-within {
     border-color: var(--border-light);
+  }
+
+  /* ── Run script list editor ──────────── */
+
+  .run-script-entry {
+    margin-bottom: 0.6rem;
+    padding: 0.55rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-sidebar);
+  }
+
+  .run-script-entry.is-default {
+    border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+  }
+
+  .run-script-entry-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 0.35rem;
+  }
+
+  .default-badge {
+    font-size: 0.6rem;
+    font-weight: 600;
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  .run-script-name-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-primary);
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 0.2rem 0;
+    outline: none;
+    font-family: inherit;
+  }
+
+  .run-script-name-input:focus {
+    border-bottom-color: var(--accent);
+  }
+
+  .run-script-name-input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .run-script-delete {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .run-script-delete:hover {
+    background: var(--bg-hover);
+    color: var(--diff-del);
+  }
+
+  .add-script-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.65rem;
+    background: none;
+    border: 1px dashed var(--border-light);
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: 0.73rem;
+    cursor: pointer;
+    font-family: inherit;
+  }
+
+  .add-script-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
   }
 
   /* ── Env hint ────────────────────────── */

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { SvelteMap } from "svelte/reactivity";
-  import type { WorkspaceInfo, RepoSettings, PrStatus, ScriptEvent } from "$lib/ipc";
-  import { runScript, closeTerminal } from "$lib/ipc";
+  import type { WorkspaceInfo, RepoSettings, PrStatus, ScriptEvent, NamedScript } from "$lib/ipc";
+  import { runScript, stopScript, closeTerminal } from "$lib/ipc";
   import type { ReviewState } from "$lib/components/ReviewPill.svelte";
   import type { ChatPanelApi, QueueDisplayItem, PastedImage } from "$lib/chat-utils";
   import type { Mention } from "$lib/components/MentionInput.svelte";
-  import { ExternalLink, Check, GitPullRequestCreate, GitMerge, ArrowUp, ArrowDown, AlertTriangle, Wrench, Eye, Play, CircleX, MessageSquare, Minus, ChevronUp, ChevronDown, Timer, RefreshCcw, Plus, X } from "lucide-svelte";
+  import { ExternalLink, Check, GitPullRequestCreate, GitMerge, ArrowUp, ArrowDown, AlertTriangle, Wrench, Eye, Play, Square, CircleX, MessageSquare, Minus, ChevronUp, ChevronDown, Timer, RefreshCcw, Plus, X } from "lucide-svelte";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import ChatPanel from "$lib/components/ChatPanel.svelte";
   import DiffViewer from "$lib/components/DiffViewer.svelte";
@@ -175,7 +175,18 @@
   let isPopoverOpen = $derived(
     selectedWsId ? scriptPopoverOpen.get(selectedWsId) ?? false : false
   );
-  let hasRunScript = $derived(!!repoSettings?.run_script?.trim());
+  let scriptDropdownOpen = new SvelteMap<string, boolean>();
+  let runningScriptName = new SvelteMap<string, string>();
+  let isDropdownOpen = $derived(
+    selectedWsId ? scriptDropdownOpen.get(selectedWsId) ?? false : false
+  );
+  let currentRunningName = $derived(
+    selectedWsId ? runningScriptName.get(selectedWsId) ?? "" : ""
+  );
+  let hasRunScripts = $derived(
+    (repoSettings?.run_scripts?.length ?? 0) > 0 &&
+    repoSettings!.run_scripts.some((s: NamedScript) => s.command.trim())
+  );
 
   let outputEl = $state<HTMLPreElement | null>(null);
 
@@ -282,18 +293,19 @@
     selectedWsId ? activeTerminalTab.get(selectedWsId) ?? null : null
   );
 
-  function handleRunScript() {
-    if (!selectedWs || !repoSettings?.run_script?.trim()) return;
+  function handleRunNamedScript(script: NamedScript) {
+    if (!selectedWs || !script.command.trim()) return;
     const wsId = selectedWs.id;
     scriptStatusMap.set(wsId, "running");
     scriptOutputMap.set(wsId, []);
     scriptExitCodeMap.delete(wsId);
     scriptPopoverOpen.set(wsId, true);
+    scriptDropdownOpen.set(wsId, false);
+    runningScriptName.set(wsId, script.name || script.command);
 
-    runScript(wsId, repoSettings.run_script, (event: ScriptEvent) => {
+    runScript(wsId, script.command, (event: ScriptEvent) => {
       if (event.type === "output") {
         const prev = scriptOutputMap.get(wsId) ?? [];
-        // Cap at 500 lines to avoid unbounded memory growth
         const lines = prev.length >= 500 ? [...prev.slice(1), event.data] : [...prev, event.data];
         scriptOutputMap.set(wsId, lines);
         requestAnimationFrame(scrollOutputToBottom);
@@ -318,10 +330,25 @@
     });
   }
 
-  function togglePopover() {
+  function handleRunDefault() {
+    const scripts = repoSettings?.run_scripts ?? [];
+    const first = scripts.find((s: NamedScript) => s.command.trim());
+    if (first) handleRunNamedScript(first);
+  }
+
+  async function handleStopScript() {
+    if (!selectedWs) return;
+    try {
+      await stopScript(selectedWs.id);
+    } catch {
+      // Process may have already exited — the exit event will handle state cleanup
+    }
+  }
+
+  function toggleDropdown() {
     if (!selectedWsId) return;
-    const open = scriptPopoverOpen.get(selectedWsId) ?? false;
-    scriptPopoverOpen.set(selectedWsId, !open);
+    const open = scriptDropdownOpen.get(selectedWsId) ?? false;
+    scriptDropdownOpen.set(selectedWsId, !open);
   }
 
   function closePopover() {
@@ -333,6 +360,7 @@
     const target = e.target as HTMLElement;
     if (!target.closest(".run-script-wrapper")) {
       closePopover();
+      if (selectedWsId) scriptDropdownOpen.set(selectedWsId, false);
     }
   }
 </script>
@@ -348,47 +376,76 @@
         <span class="breadcrumb-sep">›</span>
         <span class="breadcrumb-base">{defaultBranch}</span>
       </span>
-      {#if hasRunScript}
+      {#if hasRunScripts}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div class="run-script-wrapper" onclick={(e) => e.stopPropagation()}>
           <div class="run-script-group">
+            {#if currentScriptStatus === "running"}
+              <button
+                class="run-script-btn stop"
+                onclick={handleStopScript}
+                title="Stop script"
+              >
+                <Square size={10} />
+                Stop
+              </button>
+            {:else}
+              <button
+                class="run-script-btn"
+                class:success={currentScriptStatus === "success"}
+                class:error={currentScriptStatus === "error"}
+                onclick={handleRunDefault}
+                title={`Run: ${repoSettings?.run_scripts?.[0]?.name || repoSettings?.run_scripts?.[0]?.command || "Script"}`}
+              >
+                {#if currentScriptStatus === "success"}
+                  <Check size={12} />
+                {:else if currentScriptStatus === "error"}
+                  <CircleX size={12} />
+                {:else}
+                  <Play size={12} />
+                {/if}
+                Run
+              </button>
+            {/if}
             <button
-              class="run-script-btn"
+              class="run-script-toggle"
               class:running={currentScriptStatus === "running"}
               class:success={currentScriptStatus === "success"}
               class:error={currentScriptStatus === "error"}
-              onclick={handleRunScript}
-              disabled={currentScriptStatus === "running"}
-              title={currentScriptStatus === "running" ? "Script running…" : `Run: ${repoSettings?.run_script}`}
+              onclick={toggleDropdown}
+              title="Select script"
             >
-              {#if currentScriptStatus === "running"}
-                <span class="btn-spinner"></span>
-              {:else if currentScriptStatus === "success"}
-                <Check size={12} />
-              {:else if currentScriptStatus === "error"}
-                <CircleX size={12} />
-              {:else}
-                <Play size={12} />
-              {/if}
-              Run
+              <ChevronDown size={10} />
             </button>
-            {#if currentScriptOutput.length > 0 || currentScriptStatus === "running"}
-              <button
-                class="run-script-toggle"
-                class:running={currentScriptStatus === "running"}
-                class:success={currentScriptStatus === "success"}
-                class:error={currentScriptStatus === "error"}
-                onclick={togglePopover}
-                title={isPopoverOpen ? "Hide output" : "Show output"}
-              >
-                {#if isPopoverOpen}
-                  <ChevronUp size={10} />
-                {:else}
-                  <ChevronDown size={10} />
-                {/if}
-              </button>
-            {/if}
           </div>
+
+          {#if isDropdownOpen}
+            <div class="script-dropdown">
+              {#each repoSettings?.run_scripts ?? [] as script, i}
+                {#if script.command.trim()}
+                  <button
+                    class="script-dropdown-item"
+                    onclick={() => handleRunNamedScript(script)}
+                    disabled={currentScriptStatus === "running"}
+                  >
+                    <Play size={11} />
+                    <span class="script-dropdown-name">{script.name || script.command}</span>
+                    {#if i === 0}<span class="script-dropdown-default">default</span>{/if}
+                  </button>
+                {/if}
+              {/each}
+              {#if currentScriptOutput.length > 0 && !isPopoverOpen}
+                <div class="script-dropdown-divider"></div>
+                <button
+                  class="script-dropdown-item"
+                  onclick={() => { if (selectedWsId) { scriptPopoverOpen.set(selectedWsId, true); scriptDropdownOpen.set(selectedWsId, false); } }}
+                >
+                  <span class="script-dropdown-name">Show last output</span>
+                </button>
+              {/if}
+            </div>
+          {/if}
+
           {#if isPopoverOpen}
             <div class="script-popover">
               <div class="script-popover-header">
@@ -396,7 +453,7 @@
                   {#if currentScriptStatus === "running"}
                     <span class="btn-spinner btn-spinner-sm"></span>
                   {/if}
-                  {repoSettings?.run_script}
+                  {currentRunningName || "Script"}
                 </span>
                 <button class="script-popover-close" onclick={closePopover}>
                   <X size={12} />
@@ -839,6 +896,17 @@
     background: color-mix(in srgb, var(--diff-del) 12%, transparent);
   }
 
+  .run-script-btn.stop {
+    color: var(--diff-del);
+    border-color: color-mix(in srgb, var(--diff-del) 30%, transparent);
+    background: color-mix(in srgb, var(--diff-del) 10%, transparent);
+  }
+
+  .run-script-btn.stop:hover {
+    border-color: color-mix(in srgb, var(--diff-del) 50%, transparent);
+    background: color-mix(in srgb, var(--diff-del) 18%, transparent);
+  }
+
   /* ── Run script wrapper + popover ────────────────── */
 
   .run-script-wrapper {
@@ -892,6 +960,69 @@
 
   .run-script-toggle.running {
     cursor: default;
+  }
+
+  /* ── Script dropdown ──────────────────────────── */
+
+  .script-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    min-width: 200px;
+    background: var(--bg-base);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    z-index: 51;
+    overflow: hidden;
+    padding: 0.25rem 0;
+  }
+
+  .script-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: 100%;
+    padding: 0.35rem 0.6rem;
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .script-dropdown-item:hover:not(:disabled) {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  .script-dropdown-item:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .script-dropdown-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .script-dropdown-default {
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    background: var(--bg-sidebar);
+    padding: 0.05rem 0.35rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+
+  .script-dropdown-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 0.25rem 0;
   }
 
   .script-popover {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -515,9 +515,14 @@ export async function getPrTemplate(repoId: string): Promise<string> {
 
 // ── Repo Settings ────────────────────────────────────────────────────
 
+export interface NamedScript {
+  name: string;
+  command: string;
+}
+
 export interface RepoSettings {
   setup_script: string;
-  run_script: string;
+  run_scripts: NamedScript[];
   remove_script: string;
   pr_message: string;
   review_message: string;
@@ -551,6 +556,10 @@ export async function runScript(
   const channel = new Channel<ScriptEvent>();
   channel.onmessage = onEvent;
   return invoke("run_script", { workspaceId, command, onEvent: channel });
+}
+
+export async function stopScript(workspaceId: string): Promise<void> {
+  return invoke("stop_script", { workspaceId });
 }
 
 // ── Events ───────────────────────────────────────────────────────────

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -37,7 +37,7 @@ export async function mockTauri(
           case "plugin:event|unlisten":
             return null;
           case "get_repo_settings":
-            return { setup_script: "", run_script: "", remove_script: "" };
+            return { setup_script: "", run_scripts: [], remove_script: "" };
           case "save_repo_settings":
             return null;
           case "get_pr_status":
@@ -129,6 +129,8 @@ export async function mockTauriWithRepo(
             return "";
           case "run_script":
             return null;
+          case "stop_script":
+            return null;
           case "open_terminal":
             return null;
           case "write_terminal":
@@ -138,7 +140,7 @@ export async function mockTauriWithRepo(
           case "close_terminal":
             return null;
           case "get_repo_settings":
-            return { setup_script: "", run_script: "", remove_script: "" };
+            return { setup_script: "", run_scripts: [], remove_script: "" };
           case "save_repo_settings":
             return null;
           case "get_pr_status":


### PR DESCRIPTION
## Summary
- Replace single `run_script` with `run_scripts: Vec<NamedScript>` supporting multiple named commands per repo
- Split button UX: Play runs the default (first) script, chevron opens a dropdown to pick any script
- Add `stop_script` command that kills the entire process group (SIGTERM via process group kill)
- Backward-compatible migration from old `run_script` string format on settings load
- RepoSettings UI updated with list editor for adding/removing/naming scripts

## Test plan
- [x] `cargo check` passes
- [x] `bun run check` passes (0 errors)
- [ ] Manual: verify old `repo_settings.json` with `run_script` string migrates correctly
- [ ] Manual: add multiple scripts in RepoSettings, verify save/reload
- [ ] Manual: Run button executes default script, dropdown lists all scripts
- [ ] Manual: Stop button terminates running script and child processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)