### PR TITLE
fix: remove max-width constraint on kanban columns to fill available space

### DIFF
--- a/src/lib/components/KanbanColumn.svelte
+++ b/src/lib/components/KanbanColumn.svelte
@@ -37,7 +37,6 @@
   .column {
     flex: 1;
     min-width: 0;
-    max-width: 380px;
     display: flex;
     flex-direction: column;
     background: var(--bg-sidebar);


### PR DESCRIPTION
## Summary
- Removed `max-width: 380px` from `.column` in `KanbanColumn.svelte` that was capping each column's width
- Columns already use `flex: 1` so they now stretch evenly to fill the full board width at any window size

## Test plan
- [ ] Open kanban board at a wide window size and verify all four columns fill the width with no trailing gap
- [ ] Resize window and confirm columns shrink proportionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)