### PR TITLE
feat: render markdown in card detail overlay task description

### DIFF
--- a/src/lib/components/CardDetailOverlay.svelte
+++ b/src/lib/components/CardDetailOverlay.svelte
@@ -267,7 +267,10 @@
 
   .dialog-body {
     padding: 0.6rem 0.85rem 0.75rem;
-    overflow-y: auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
 
   .ws-title {
@@ -285,6 +288,8 @@
     line-height: 1.45;
     margin: 0.4rem 0 0;
     word-break: break-word;
+    overflow-y: auto;
+    min-height: 0;
   }
 
   /* ── Markdown body (task description) ─── */


### PR DESCRIPTION
## Summary
- Task descriptions in the card detail overlay now render as markdown (headers, lists, links, code blocks) instead of plain text, using the existing `renderMarkdown` + DOMPurify pipeline.
- Links in rendered descriptions open in the system browser via `externalLinks` action.
- Only the markdown description scrolls — title, detail rows (branch/changes/PR), and footer stay fixed.

## Test plan
- [ ] Click a workspace card on the kanban board to open the detail overlay
- [ ] Verify markdown in task description renders properly (headers, lists, code, links)
- [ ] Verify clicking links opens them in system browser
- [ ] Verify only the description area scrolls when content overflows, not the branch/PR rows or footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)