### PR TITLE
fix: reset to kanban view on repo switch to avoid stale workspace pages

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -679,6 +679,8 @@
 
     activeRepo = repo;
     selectedWsId = null;
+    appMode = "plan";
+    showSettings = false;
 
     // Restore autopilot state for the repo we're entering
     restoreAutopilotForRepo(repo.id);


### PR DESCRIPTION
## Summary
- Resets `appMode` to `"plan"` (kanban board) when switching repos, preventing users from landing on a stale workspace panel with no selected workspace
- Also resets `showSettings` to prevent the settings panel from persisting across repo switches

## Test plan
- [ ] Switch repos while viewing a workspace (work mode) — should land on kanban board
- [ ] Switch repos while settings panel is open — should close settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)