### PR TITLE
feat: add toggle button to show/hide terminal pane

### DIFF
--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -490,7 +490,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 0.75rem;
+    padding: 0 0.5rem;
     height: 40px;
     border-bottom: 1px solid var(--border);
     background: var(--bg-titlebar);

--- a/src/lib/components/WorkspacePanel.svelte
+++ b/src/lib/components/WorkspacePanel.svelte
@@ -60,12 +60,14 @@
     stagingMergedCount?: number;
     stagingConflictingCount?: number;
     contextWarning?: boolean;
+    terminalPaneVisible?: boolean;
   }
 
   let {
     activeTab = $bindable("diff"),
     fileNavigatePath = $bindable(null),
     fileNavigateLine = $bindable(null),
+    terminalPaneVisible = $bindable(false),
     selectedWs,
     selectedWsId,
     activeWorkspaces,
@@ -213,7 +215,6 @@
     chatDragOffset = { x: resizeStartDrag.x + posDelta.dx, y: resizeStartDrag.y + posDelta.dy };
   }
 
-  let terminalPaneVisible = $state(false);
   let terminalPaneWidth = $state(400);
   const TERMINAL_PANE_MIN = 200;
   const TERMINAL_PANE_MAX = 800;
@@ -554,7 +555,7 @@
             class="terminal-toggle-btn"
             class:active={terminalPaneVisible}
             onclick={() => { terminalPaneVisible = !terminalPaneVisible; }}
-            use:tooltip={{ text: terminalPaneVisible ? "Hide terminal" : "Show terminal" }}
+            use:tooltip={{ text: "Toggle terminal", shortcut: "⌘`" }}
           >
             <Terminal size={13} />
           </button>
@@ -782,7 +783,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
-    padding: 0 1rem;
+    padding: 0 0.5rem;
     height: 38px;
     border-bottom: 1px solid var(--border);
     flex-shrink: 0;
@@ -875,29 +876,31 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 22px;
+    height: 22px;
     padding: 0;
     background: transparent;
-    border: none;
+    border: 1px solid var(--border-light);
     border-radius: 4px;
     color: var(--text-dim);
     cursor: pointer;
     flex-shrink: 0;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
   }
 
-  .terminal-toggle-btn:hover {
+  .terminal-toggle-btn:hover:not(.active) {
     color: var(--text-primary);
     background: var(--bg-hover);
   }
 
   .terminal-toggle-btn.active {
     color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
   }
 
   .terminal-toggle-btn.active:hover {
-    color: var(--accent);
-    background: var(--bg-hover);
+    filter: brightness(1.15);
   }
 
   /* ── Run script button ──────────────────────────── */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -103,6 +103,7 @@
   let selectedWsId = $state<string | null>(null);
   let activeTab = $state<PanelTab>("diff");
   let chatExpanded = $state(true);
+  let terminalPaneVisible = $state(false);
   let diffRefreshTrigger = $state(0);
   let showSettings = $state(false);
   let creatingWsId = $state<string | null>(null);
@@ -722,6 +723,12 @@
           if (!inInput && selectedWsId && appMode === "work") {
             e.preventDefault();
             handleUpdateBranch();
+          }
+          break;
+        case "`":
+          if (appMode === "work") {
+            e.preventDefault();
+            terminalPaneVisible = !terminalPaneVisible;
           }
           break;
       }
@@ -2301,6 +2308,7 @@
             bind:activeTab
             bind:fileNavigatePath
             bind:fileNavigateLine
+            bind:terminalPaneVisible
             {chatExpanded}
             onChatExpandedChange={(v) => { chatExpanded = v; }}
             defaultBranch={activeRepo?.default_branch ?? "main"}


### PR DESCRIPTION
## Summary
- Adds a terminal icon toggle button on the right edge of the left pane's tab bar (Diff/Files)
- Terminal pane is hidden by default and can be toggled on/off
- Uses `display: none/block` to hide the pane (xterm instances stay mounted, never unmounted)
- All styles use theme tokens — no hardcoded values

## Test plan
- [ ] Verify terminal pane is hidden on initial load
- [ ] Click the terminal icon to show the pane, click again to hide
- [ ] Confirm xterm terminals still work after toggling visibility
- [ ] Check resize handle appears/disappears with the terminal pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)