### PR TITLE
feat: add manual checkout dialog for custom branch names

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -331,7 +331,7 @@ pub fn send_message(
 ) -> Result<(), String> {
     let plan_mode = plan_mode.unwrap_or(false);
     let thinking_mode = thinking_mode.unwrap_or(false);
-    let (worktree_path, gh_profile, _repo_id, ws_branch, repo_path, user_system_prompt, context_dir) = {
+    let (worktree_path, gh_profile, _repo_id, ws_branch, repo_path, user_system_prompt, context_dir, is_custom_branch) = {
         let st = state.lock().map_err(|e| e.to_string())?;
         if st.agents.contains_key(&workspace_id) {
             return Err("Agent is already processing a message".into());
@@ -354,6 +354,7 @@ pub fn send_message(
             repo.path.clone(),
             user_sp,
             ctx_dir,
+            ws.custom_branch,
         )
     };
 
@@ -472,6 +473,15 @@ pub fn send_message(
             .unwrap_or_else(|_| "main".to_string());
         let wt_display = worktree_path.to_string_lossy();
         let repo_display = repo_path.to_string_lossy();
+        let rename_instruction = if !is_custom_branch {
+            "Use the rename_branch tool to give your branch a meaningful name based on the task. \
+             Use conventional prefixes: feat/, fix/, refactor/, chore/, docs/. Keep names concise (<30 chars).\n\
+             IMPORTANT: Renaming the branch is your FIRST priority. Call rename_branch BEFORE reading files, writing code, or running any commands. \
+             Parse the user's request, pick a name, and rename immediately.\n\
+             If the task scope changes mid-conversation, rename the branch again to reflect the new direction."
+        } else {
+            "The branch was manually named by the user. Do NOT rename it unless the user explicitly asks you to."
+        };
         let mut system_prompt = format!(
             "You are working inside Korlap, a Mac app that runs coding agents in parallel.\n\
              Your working directory is already set to the workspace. Do not cd into it — you are already there.\n\
@@ -487,9 +497,8 @@ pub fn send_message(
              • Do NOT use the Agent tool with isolation: \"worktree\" — it will create a worktree from the wrong repo.\n\
              • If you discover paths outside {wt_display}, ignore them. You have no business there.\n\
              \n\
-             You have access to Korlap tools via MCP. Use the rename_branch tool to give your branch a meaningful name based on the task. Use conventional prefixes: feat/, fix/, refactor/, chore/, docs/. Keep names concise (<30 chars).\n\
-             IMPORTANT: Renaming the branch is your FIRST priority. Call rename_branch BEFORE reading files, writing code, or running any commands. Parse the user's request, pick a name, and rename immediately.\n\
-             If the task scope changes mid-conversation, rename the branch again to reflect the new direction.\n\
+             You have access to Korlap tools via MCP.\n\
+             {rename_instruction}\n\
              Keep all changes on the target branch. Do not modify other branches.\n\
              \n\
              You have LSP tools for compiler-accurate code navigation:\n\

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -195,6 +195,7 @@ pub async fn create_staging_workspace(
         task_title: Some("Staging".to_string()),
         task_description: None,
         source_todo_id: None,
+        custom_branch: false,
     };
 
     let mut st = state.lock().map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -48,6 +48,7 @@ pub async fn create_workspace(
     task_title: Option<String>,
     task_description: Option<String>,
     source_todo_id: Option<String>,
+    custom_branch: Option<String>,
     state: State<'_, Arc<Mutex<AppState>>>,
 ) -> Result<WorkspaceInfo, String> {
     let (repo_path, gh_profile) = {
@@ -141,43 +142,65 @@ pub async fn create_workspace(
 
     let start_point = format!("origin/{}", base_branch);
 
-    // Generate a unique name (retry if branch already exists)
-    let mut name = random_workspace_name();
     let worktree_base = {
         let st = state.lock().map_err(|e| e.to_string())?;
         st.worktree_dir()
     };
 
-    for attempt in 0..10 {
-        let branch = format!("korlap/{}", name);
+    // When a custom branch is provided, use it directly; otherwise generate a random one.
+    let (dir_name, branch, display_name) = if let Some(ref cb) = custom_branch {
+        let cb = cb.trim().to_string();
+        if cb.is_empty() {
+            return Err("Branch name cannot be empty".into());
+        }
+
+        // Check if branch already exists
         let check = std::process::Command::new("git")
-            .args(["rev-parse", "--verify", &branch])
+            .args(["rev-parse", "--verify", &cb])
             .current_dir(&repo_path)
             .output()
             .map_err(|e| format!("Failed to run git: {}", e))?;
-
-        let folder_exists = worktree_base.join(&name).exists();
-
-        if !check.status.success() && !folder_exists {
-            break; // branch doesn't exist and folder is free, good to use
+        if check.status.success() {
+            return Err(format!("Branch '{}' already exists", cb));
         }
 
-        if attempt == 9 {
-            return Err("Could not generate a unique workspace name after 10 attempts".into());
-        }
+        // Use a random dir name to avoid filesystem issues with slashes in branch names
+        let dir = random_workspace_name();
+        (dir, cb.clone(), cb)
+    } else {
+        let mut name = random_workspace_name();
+        for attempt in 0..10 {
+            let branch = format!("korlap/{}", name);
+            let check = std::process::Command::new("git")
+                .args(["rev-parse", "--verify", &branch])
+                .current_dir(&repo_path)
+                .output()
+                .map_err(|e| format!("Failed to run git: {}", e))?;
 
-        name = format!(
-            "{}-{}",
-            random_workspace_name(),
-            &Uuid::new_v4().to_string()[..4]
-        );
-    }
+            let folder_exists = worktree_base.join(&name).exists();
+
+            if !check.status.success() && !folder_exists {
+                break;
+            }
+
+            if attempt == 9 {
+                return Err("Could not generate a unique workspace name after 10 attempts".into());
+            }
+
+            name = format!(
+                "{}-{}",
+                random_workspace_name(),
+                &Uuid::new_v4().to_string()[..4]
+            );
+        }
+        let branch = format!("korlap/{}", name);
+        (name.clone(), branch, name)
+    };
 
     let id = Uuid::new_v4().to_string();
-    let branch = format!("korlap/{}", name);
 
     // Worktree lives in app data dir, named after the workspace for human readability
-    let worktree_path = worktree_base.join(&name);
+    let worktree_path = worktree_base.join(&dir_name);
 
     std::fs::create_dir_all(worktree_path.parent().unwrap_or(&worktree_path))
         .map_err(|e| e.to_string())?;
@@ -197,7 +220,7 @@ pub async fn create_workspace(
 
     let ws = WorkspaceInfo {
         id: id.clone(),
-        name,
+        name: display_name,
         branch,
         worktree_path: worktree_path.clone(),
         repo_id: repo_id.clone(),
@@ -207,6 +230,7 @@ pub async fn create_workspace(
         task_title,
         task_description,
         source_todo_id,
+        custom_branch: custom_branch.is_some(),
     };
 
     // Check if there's a setup script to run

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -34,6 +34,8 @@ pub struct WorkspaceInfo {
     pub task_description: Option<String>,
     #[serde(default)]
     pub source_todo_id: Option<String>,
+    #[serde(default)]
+    pub custom_branch: bool,
 }
 
 pub struct AgentHandle {

--- a/src/lib/components/KanbanBoard.svelte
+++ b/src/lib/components/KanbanBoard.svelte
@@ -5,8 +5,9 @@
   import KanbanCard from "./KanbanCard.svelte";
   import CardDetailOverlay from "./CardDetailOverlay.svelte";
   import TaskPopover, { type TaskData } from "./TaskPopover.svelte";
+  import ManualCheckoutPopover, { type ManualCheckoutData } from "./ManualCheckoutPopover.svelte";
   import AutopilotPill, { type AutopilotEvent } from "./AutopilotPill.svelte";
-  import { Plus, Ellipsis, Trash2 } from "lucide-svelte";
+  import { Plus, Ellipsis, Trash2, GitBranch } from "lucide-svelte";
   import { tooltip } from "$lib/actions";
 
   interface TodoItem {
@@ -45,6 +46,7 @@
     onToggleReady: (todoId: string) => void;
     onRemoveWorkspace: (wsId: string) => void;
     onRemoveAllDone: () => void;
+    onManualCheckout: (data: ManualCheckoutData) => void;
     autopilotEnabled?: boolean;
     autopilotEvents?: AutopilotEvent[];
     autopilotActiveAgents?: number;
@@ -77,6 +79,7 @@
     onToggleReady,
     onRemoveWorkspace,
     onRemoveAllDone,
+    onManualCheckout,
     autopilotEnabled = false,
     autopilotEvents = [],
     autopilotActiveAgents = 0,
@@ -89,6 +92,7 @@
   }: Props = $props();
 
   let showAddDialog = $state(false);
+  let showManualCheckout = $state(false);
   let editingTodo = $state<TodoItem | null>(null);
   let showDoneMenu = $state(false);
   let doneMenuBtnEl = $state<HTMLButtonElement | null>(null);
@@ -135,7 +139,7 @@
   function handleBoardKeydown(e: KeyboardEvent) {
     if (!active) return;
     if (e.defaultPrevented) return;
-    if (showAddDialog || editingTodo || detailWs || showDoneMenu) return;
+    if (showAddDialog || showManualCheckout || editingTodo || detailWs || showDoneMenu) return;
 
     const target = e.target as HTMLElement;
     if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) return;
@@ -232,6 +236,11 @@
     showAddDialog = false;
   }
 
+  function handleManualCheckoutSubmit(data: ManualCheckoutData) {
+    onManualCheckout(data);
+    showManualCheckout = false;
+  }
+
   function handleEditSubmit(data: TaskData) {
     if (editingTodo) {
       onEditTodo(editingTodo.id, data);
@@ -268,9 +277,14 @@
       <div class="empty-hint">Add a task to get started</div>
     {/if}
     {#snippet footer()}
-      <button class="add-task-btn" onclick={() => { showAddDialog = true; }} use:tooltip={{ text: "New task", shortcut: "⌘N" }}>
-        <Plus size={12} /> New task
-      </button>
+      <div class="footer-buttons">
+        <button class="add-task-btn" onclick={() => { showAddDialog = true; }} use:tooltip={{ text: "New task", shortcut: "⌘N" }}>
+          <Plus size={12} /> New task
+        </button>
+        <button class="manual-checkout-btn" onclick={() => { showManualCheckout = true; }} use:tooltip={{ text: "Manual checkout" }}>
+          <GitBranch size={13} />
+        </button>
+      </div>
     {/snippet}
   </KanbanColumn>
 
@@ -364,6 +378,13 @@
   />
 {/if}
 
+{#if showManualCheckout}
+  <ManualCheckoutPopover
+    onSubmit={handleManualCheckoutSubmit}
+    onCancel={() => { showManualCheckout = false; }}
+  />
+{/if}
+
 {#if editingTodo}
   <TaskPopover
     {repoId}
@@ -431,8 +452,13 @@
     padding: 1.5rem 0.5rem;
   }
 
+  .footer-buttons {
+    display: flex;
+    gap: 0.35rem;
+  }
+
   .add-task-btn {
-    width: 100%;
+    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -452,6 +478,27 @@
   .add-task-btn:hover {
     background: color-mix(in srgb, var(--accent) 20%, transparent);
     border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+
+  .manual-checkout-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    flex-shrink: 0;
+    padding: 0;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-dim);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+  }
+
+  .manual-checkout-btn:hover {
+    background: var(--border);
+    border-color: var(--border-light);
+    color: var(--text-secondary);
   }
 
   .column-menu-btn {

--- a/src/lib/components/ManualCheckoutPopover.svelte
+++ b/src/lib/components/ManualCheckoutPopover.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  export interface ManualCheckoutData {
+    branchName: string;
+    description: string;
+  }
+
+  interface Props {
+    onSubmit: (data: ManualCheckoutData) => void;
+    onCancel: () => void;
+  }
+
+  let { onSubmit, onCancel }: Props = $props();
+
+  let branchName = $state("");
+  let description = $state("");
+  let branchRef: HTMLInputElement | undefined = $state();
+
+  $effect(() => {
+    requestAnimationFrame(() => branchRef?.focus());
+  });
+
+  let canSubmit = $derived(branchName.trim().length > 0);
+
+  function submit() {
+    if (!canSubmit) return;
+    onSubmit({ branchName: branchName.trim(), description: description.trim() });
+  }
+
+  function handleOverlayKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+    if (e.key === "Enter" && e.metaKey) {
+      e.preventDefault();
+      submit();
+    }
+  }
+
+  function handleBranchKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && !e.metaKey) {
+      e.preventDefault();
+      descRef?.focus();
+    }
+  }
+
+  let descRef: HTMLTextAreaElement | undefined = $state();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onclick={onCancel} onkeydown={handleOverlayKeydown}>
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div class="dialog" onclick={(e) => e.stopPropagation()}>
+    <div class="dialog-header">Manual checkout</div>
+    <input
+      class="branch-input"
+      bind:this={branchRef}
+      bind:value={branchName}
+      onkeydown={handleBranchKeydown}
+      placeholder="feat/my-feature"
+      spellcheck={false}
+    />
+    <textarea
+      class="desc-input"
+      bind:this={descRef}
+      bind:value={description}
+      placeholder="Description (optional)"
+      rows={3}
+    ></textarea>
+    <div class="dialog-footer">
+      <span class="footer-hint">⌘Enter to create</span>
+      <div class="footer-actions">
+        <button class="cancel-btn" onclick={onCancel}>Cancel</button>
+        <button class="submit-btn" onclick={submit} disabled={!canSubmit}>Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .dialog {
+    width: 420px;
+    max-width: 90vw;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    background: color-mix(in srgb, var(--bg-sidebar) 97%, white);
+    border: 0.5px solid color-mix(in srgb, var(--border-light) 60%, transparent);
+    border-radius: 12px;
+    box-shadow:
+      0 0 0 0.5px rgba(0, 0, 0, 0.3),
+      0 8px 32px rgba(0, 0, 0, 0.45),
+      0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .dialog-header {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    padding: 0 0.1rem 0.15rem;
+  }
+
+  .branch-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.55rem 0.65rem;
+    background: var(--input-inset-bg);
+    border: none;
+    border-radius: 8px;
+    color: var(--text-bright);
+    font-family: var(--font-mono);
+    font-size: 0.92rem;
+    font-weight: 600;
+    outline: none;
+  }
+
+  .branch-input::placeholder {
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+
+  .branch-input:focus {
+    background: var(--input-inset-focus);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+  }
+
+  .desc-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.55rem 0.65rem;
+    background: var(--input-inset-bg);
+    border: none;
+    border-radius: 8px;
+    color: var(--text-bright);
+    font-family: inherit;
+    font-size: 0.85rem;
+    outline: none;
+    resize: vertical;
+    min-height: 60px;
+  }
+
+  .desc-input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .desc-input:focus {
+    background: var(--input-inset-focus);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+  }
+
+  .dialog-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 0.15rem;
+  }
+
+  .footer-hint {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    opacity: 0.7;
+  }
+
+  .footer-actions {
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+  }
+
+  .cancel-btn {
+    padding: 0.35rem 0.7rem;
+    background: var(--btn-subtle-bg);
+    border: none;
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-family: inherit;
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+
+  .cancel-btn:hover {
+    background: var(--btn-subtle-hover);
+    color: var(--text-primary);
+  }
+
+  .submit-btn {
+    padding: 0.35rem 0.9rem;
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    color: var(--bg-base);
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .submit-btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  .submit-btn:hover:not(:disabled) {
+    filter: brightness(1.1);
+  }
+</style>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -29,6 +29,7 @@ export interface WorkspaceInfo {
   task_title?: string | null;
   task_description?: string | null;
   source_todo_id?: string | null;
+  custom_branch?: boolean;
 }
 
 export interface ToolUseInfo {
@@ -172,12 +173,14 @@ export async function createWorkspace(
   taskTitle?: string,
   taskDescription?: string,
   sourceTodoId?: string,
+  customBranch?: string,
 ): Promise<WorkspaceInfo> {
   return invoke<WorkspaceInfo>("create_workspace", {
     repoId,
     taskTitle: taskTitle ?? null,
     taskDescription: taskDescription ?? null,
     sourceTodoId: sourceTodoId ?? null,
+    customBranch: customBranch ?? null,
   });
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -929,6 +929,44 @@
     });
   }
 
+  function handleManualCheckout(data: { branchName: string; description: string }) {
+    if (!activeRepo || creatingWsId) return;
+
+    const repoId = activeRepo.id;
+    const tempId = `creating-${crypto.randomUUID()}`;
+    const placeholder: WorkspaceInfo = {
+      id: tempId,
+      name: data.branchName,
+      branch: data.branchName,
+      worktree_path: "",
+      repo_id: repoId,
+      gh_profile: null,
+      status: "waiting",
+      created_at: Date.now() / 1000,
+      task_description: data.description || null,
+    };
+    creatingWsId = tempId;
+    workspaces.push(placeholder);
+    selectWorkspace(tempId);
+    appMode = "work";
+    chatExpanded = true;
+
+    createWorkspace(repoId, undefined, data.description || undefined, undefined, data.branchName)
+      .then((ws) => {
+        const idx = workspaces.findIndex((w) => w.id === tempId);
+        if (idx >= 0) workspaces[idx] = ws;
+        selectedWsId = ws.id;
+        creatingWsId = null;
+      })
+      .catch((e) => {
+        const failIdx = workspaces.findIndex((w) => w.id === tempId);
+        if (failIdx >= 0) workspaces.splice(failIdx, 1);
+        if (selectedWsId === tempId) selectedWsId = null;
+        creatingWsId = null;
+        addToast(String(e));
+      });
+  }
+
   // ── Todo handlers ──────────────────────────────────────
 
   function persistTodos() {
@@ -2492,6 +2530,7 @@
             onToggleReady={handleToggleReady}
             onRemoveWorkspace={handleRemove}
             onRemoveAllDone={handleRemoveAllDone}
+            onManualCheckout={handleManualCheckout}
             {autopilotEnabled}
             {autopilotEvents}
             autopilotActiveAgents={activeAgentCount}


### PR DESCRIPTION
## Summary
- Adds a GitBranch icon button beside "+ New task" in the kanban board for creating workspaces with user-specified branch names
- Skips AI-based auto-branch renaming — workspace goes directly to In Progress with the exact branch name provided
- Adds `custom_branch` flag to `WorkspaceInfo` so the agent system prompt conditionally omits the rename-first instruction

## Test plan
- [ ] Open kanban → click GitBranch icon → enter branch name + description → Create → workspace appears in In Progress with correct branch name
- [ ] Try creating with an already-existing branch name → should see error toast
- [ ] Send a message in a manually-checked-out workspace → agent should NOT auto-rename the branch
- [ ] Verify normal "+ New task" flow still auto-renames as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)