### PR TITLE
feat: add stop and restart controls for LSP servers

### DIFF
--- a/src-tauri/src/commands/lsp.rs
+++ b/src-tauri/src/commands/lsp.rs
@@ -2,7 +2,7 @@ use crate::lsp;
 use crate::lsp::server::LspServerPool;
 use crate::lsp::types::{config_for_extension, resolve_configs, LspServerKey};
 use crate::state::AppState;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, State};
 
@@ -279,6 +279,131 @@ pub struct LspDiagnostic {
     pub source: String,
 }
 
+// ── Shared spawn helper ─────────────────────────────────────────────
+
+/// Spawn a single LSP server in a background thread. Emits lsp-status events.
+/// Does NOT hold LspServerPool mutex across the spawn — only brief locks.
+fn spawn_server_background(
+    key: LspServerKey,
+    config: lsp::types::LspServerConfig,
+    project_root: PathBuf,
+    worktree_project_dir: PathBuf,
+    lsp_mgr: Arc<Mutex<LspServerPool>>,
+    app: AppHandle,
+) {
+    std::thread::spawn(move || {
+        // 1. Brief mutex hold: validate binary, check if already running
+        let binary_path = {
+            let mut mgr = match lsp_mgr.lock() {
+                Ok(m) => m,
+                Err(e) => {
+                    let _ = app.emit("lsp-status", serde_json::json!({
+                        "repo_id": key.repo_id,
+                        "server_id": key.server_id,
+                        "status": "error",
+                        "message": format!("{}", e),
+                    }));
+                    return;
+                }
+            };
+            match mgr.prepare_start(&key, &config) {
+                Ok(Some(path)) => path,
+                Ok(None) => {
+                    // Already running
+                    let _ = app.emit("lsp-status", serde_json::json!({
+                        "repo_id": key.repo_id,
+                        "server_id": key.server_id,
+                        "status": "ready",
+                        "message": format!("{} language server ready", key.server_id),
+                    }));
+                    return;
+                }
+                Err(e) => {
+                    let _ = app.emit("lsp-status", serde_json::json!({
+                        "repo_id": key.repo_id,
+                        "server_id": key.server_id,
+                        "status": "error",
+                        "message": format!("{}", e),
+                    }));
+                    return;
+                }
+            }
+            // LspManager mutex released here
+        };
+
+        let _ = app.emit("lsp-status", serde_json::json!({
+            "repo_id": key.repo_id,
+            "server_id": key.server_id,
+            "status": "starting",
+            "message": format!("Starting {} language server...", key.server_id),
+        }));
+
+        // 2. Start server WITHOUT holding LspManager mutex
+        let result = lsp::server::start_server(&binary_path, &config, &project_root);
+
+        match result {
+            Ok(handle) => {
+                let _ = lsp::add_worktree(&handle, &worktree_project_dir);
+
+                // 3. Brief mutex hold: insert handle — now visible to UI via get_existing
+                if let Ok(mut mgr) = lsp_mgr.lock() {
+                    mgr.insert(key.clone(), handle.clone());
+                }
+
+                let _ = app.emit("lsp-status", serde_json::json!({
+                    "repo_id": key.repo_id,
+                    "server_id": key.server_id,
+                    "status": "indexing",
+                    "message": format!("{} indexing...", key.server_id),
+                }));
+
+                // 4. Wait for readiness WITHOUT holding mutex (10-60s)
+                let _ = lsp::server::wait_for_ready(&handle, &project_root);
+
+                let _ = app.emit("lsp-status", serde_json::json!({
+                    "repo_id": key.repo_id,
+                    "server_id": key.server_id,
+                    "status": "ready",
+                    "message": format!("{} ready", key.server_id),
+                }));
+            }
+            Err(e) => {
+                let _ = app.emit("lsp-status", serde_json::json!({
+                    "repo_id": key.repo_id,
+                    "server_id": key.server_id,
+                    "status": "error",
+                    "message": format!("{}", e),
+                }));
+            }
+        }
+    });
+}
+
+/// Resolve config + project root for a single server_id in a repo.
+fn resolve_single_server(
+    repo_path: &Path,
+    configs: &std::collections::HashMap<String, lsp::types::LspServerConfig>,
+    server_id: &str,
+) -> Option<(lsp::types::LspServerConfig, PathBuf)> {
+    let config = configs.get(server_id)?;
+    let project_root = lsp::detect::detect_project_root(repo_path, config)?;
+    Some((config.clone(), project_root))
+}
+
+/// Compute the worktree project directory (maps repo-relative subdir into worktree).
+fn compute_worktree_project_dir(
+    repo_path: &Path,
+    project_root: &Path,
+    worktree_path: &Path,
+) -> PathBuf {
+    if let Ok(subdir) = project_root.strip_prefix(repo_path) {
+        if !subdir.as_os_str().is_empty() {
+            return worktree_path.join(subdir);
+        }
+    }
+    worktree_path.to_path_buf()
+}
+
 // ── Tauri commands (all async, never block the UI) ──────────────────
 
 /// Start LSP server(s) for a workspace in the background.
@@ -319,103 +444,97 @@ pub async fn lsp_start_server(
             }
         }
 
-        let config_owned = config.clone();
-        let project_root = project_root.clone();
-        // Compute worktree project dir: if project is in a subdirectory (e.g., "backend/"),
-        // register <worktree>/backend/ instead of just <worktree>/ so the LSP server
-        // can find pyproject.toml, source roots, etc. in the worktree too.
-        let worktree_project_dir = if let Ok(subdir) = project_root.strip_prefix(&repo_path) {
-            if !subdir.as_os_str().is_empty() {
-                worktree_path.join(subdir)
-            } else {
-                worktree_path.clone()
-            }
-        } else {
-            worktree_path.clone()
-        };
-        let lsp_mgr = lsp_mgr.clone();
-        let app = app.clone();
+        let worktree_project_dir = compute_worktree_project_dir(&repo_path, &project_root, &worktree_path);
 
-        std::thread::spawn(move || {
-            // 1. Brief mutex hold: validate binary, check if already running
-            let binary_path = {
-                let mut mgr = match lsp_mgr.lock() {
-                    Ok(m) => m,
-                    Err(e) => {
-                        let _ = app.emit("lsp-status", serde_json::json!({
-                            "server_id": key.server_id,
-                            "status": "error",
-                            "message": format!("{}", e),
-                        }));
-                        return;
-                    }
-                };
-                match mgr.prepare_start(&key, &config_owned) {
-                    Ok(Some(path)) => path,
-                    Ok(None) => {
-                        // Already running
-                        let _ = app.emit("lsp-status", serde_json::json!({
-                            "server_id": key.server_id,
-                            "status": "ready",
-                            "message": format!("{} language server ready", key.server_id),
-                        }));
-                        return;
-                    }
-                    Err(e) => {
-                        let _ = app.emit("lsp-status", serde_json::json!({
-                            "server_id": key.server_id,
-                            "status": "error",
-                            "message": format!("{}", e),
-                        }));
-                        return;
-                    }
-                }
-                // LspManager mutex released here
-            };
-
-            let _ = app.emit("lsp-status", serde_json::json!({
-                "server_id": key.server_id,
-                "status": "starting",
-                "message": format!("Starting {} language server...", key.server_id),
-            }));
-
-            // 2. Start server WITHOUT holding LspManager mutex
-            let result = lsp::server::start_server(&binary_path, &config_owned, &project_root);
-
-            match result {
-                Ok(handle) => {
-                    let _ = lsp::add_worktree(&handle, &worktree_project_dir);
-
-                    // 3. Brief mutex hold: insert handle — now visible to UI via get_existing
-                    if let Ok(mut mgr) = lsp_mgr.lock() {
-                        mgr.insert(key.clone(), handle.clone());
-                    }
-
-                    let _ = app.emit("lsp-status", serde_json::json!({
-                        "server_id": key.server_id,
-                        "status": "indexing",
-                        "message": format!("{} indexing...", key.server_id),
-                    }));
-
-                    // 4. Wait for readiness WITHOUT holding mutex (10-60s)
-                    let _ = lsp::server::wait_for_ready(&handle, &project_root);
-
-                    let _ = app.emit("lsp-status", serde_json::json!({
-                        "server_id": key.server_id,
-                        "status": "ready",
-                        "message": format!("{} ready", key.server_id),
-                    }));
-                }
-                Err(e) => {
-                    let _ = app.emit("lsp-status", serde_json::json!({
-                        "server_id": key.server_id,
-                        "status": "error",
-                        "message": format!("{}", e),
-                    }));
-                }
-            }
-        });
+        spawn_server_background(
+            key,
+            config.clone(),
+            project_root.clone(),
+            worktree_project_dir,
+            lsp_mgr.clone(),
+            app.clone(),
+        );
     }
+
+    Ok(())
+}
+
+/// Stop a single LSP server for a repo.
+#[tauri::command]
+pub async fn lsp_stop_server(
+    repo_id: String,
+    server_id: String,
+    app: AppHandle,
+    lsp_manager: State<'_, Arc<Mutex<LspServerPool>>>,
+) -> Result<(), String> {
+    let key = LspServerKey {
+        repo_id: repo_id.clone(),
+        server_id: server_id.clone(),
+    };
+
+    let stopped = {
+        let mut mgr = lsp_manager.lock().map_err(|e| e.to_string())?;
+        mgr.stop_server(&key)
+    };
+
+    if stopped {
+        let _ = app.emit("lsp-status", serde_json::json!({
+            "repo_id": repo_id,
+            "server_id": server_id,
+            "status": "stopped",
+            "message": format!("{} stopped", server_id),
+        }));
+    }
+
+    Ok(())
+}
+
+/// Stop then restart a single LSP server. Requires workspace_id to resolve
+/// the worktree path for re-registering workspace folders.
+#[tauri::command]
+pub async fn lsp_restart_server(
+    repo_id: String,
+    server_id: String,
+    workspace_id: String,
+    app: AppHandle,
+    state: State<'_, Arc<Mutex<AppState>>>,
+    lsp_manager: State<'_, Arc<Mutex<LspServerPool>>>,
+) -> Result<(), String> {
+    let key = LspServerKey {
+        repo_id: repo_id.clone(),
+        server_id: server_id.clone(),
+    };
+
+    // 1. Stop existing server (if running)
+    {
+        let mut mgr = lsp_manager.lock().map_err(|e| e.to_string())?;
+        mgr.stop_server(&key);
+    }
+
+    // 2. Resolve paths
+    let (_ws_repo_id, repo_path, worktree_path) = resolve_ws(state.inner(), &workspace_id)?;
+
+    let user_overrides = state
+        .lock()
+        .ok()
+        .and_then(|st| st.repo_settings.get(&repo_id).map(|s| s.lsp_servers.clone()))
+        .unwrap_or_default();
+    let configs = resolve_configs(&user_overrides);
+
+    let (config, project_root) = resolve_single_server(&repo_path, &configs, &server_id)
+        .ok_or_else(|| format!("No LSP config found for server '{}'", server_id))?;
+
+    let worktree_project_dir = compute_worktree_project_dir(&repo_path, &project_root, &worktree_path);
+
+    // 3. Spawn in background
+    spawn_server_background(
+        key,
+        config,
+        project_root,
+        worktree_project_dir,
+        lsp_manager.inner().clone(),
+        app,
+    );
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,6 +171,8 @@ pub fn run() {
             commands::context::resolve_contradiction,
             // lsp
             commands::lsp::lsp_start_server,
+            commands::lsp::lsp_stop_server,
+            commands::lsp::lsp_restart_server,
             commands::lsp::lsp_get_status,
             commands::lsp::lsp_hover,
             commands::lsp::lsp_goto_definition,

--- a/src-tauri/src/lsp/server.rs
+++ b/src-tauri/src/lsp/server.rs
@@ -122,6 +122,7 @@ impl LspServerPool {
                 let mut handle = handle_arc.lock().ok()?;
                 if matches!(handle.child.try_wait(), Ok(None)) {
                     Some(serde_json::json!({
+                        "repo_id": key.repo_id,
                         "server_id": key.server_id,
                         "status": if handle.initialized { "ready" } else { "starting" },
                     }))
@@ -183,6 +184,18 @@ impl LspServerPool {
         }
         for key in keys_to_remove {
             self.servers.remove(&key);
+        }
+    }
+
+    /// Shut down a single server by key. Returns true if it was running.
+    pub fn stop_server(&mut self, key: &LspServerKey) -> bool {
+        if let Some(handle_arc) = self.servers.remove(key) {
+            if let Ok(mut handle) = handle_arc.lock() {
+                let _ = shutdown_server(&mut handle);
+            }
+            true
+        } else {
+            false
         }
     }
 

--- a/src/lib/components/RepoSettings.svelte
+++ b/src/lib/components/RepoSettings.svelte
@@ -3,10 +3,11 @@
     getRepoSettings, saveRepoSettings, type RepoSettings, type NamedScript, type LspServerConfig,
     getContextMeta, saveContextScope, buildKnowledgeBase, stopContextBuild,
     readContextFile, writeContextFile, draftContradictionResolution, resolveContradiction, updateKnowledgeBaseIncremental,
+    lspStopServer, lspRestartServer,
     type ContextMeta, type ContextBuildStatus, type AgentEvent,
   } from "$lib/ipc";
   import { onMount } from "svelte";
-  import { ArrowLeft, Terminal, Bot, Palette, BookOpen, Loader2, Pencil, Trash2, ChevronDown, Sun, Moon, Monitor, Braces, Plus, RotateCcw } from "lucide-svelte";
+  import { ArrowLeft, Terminal, Bot, Palette, BookOpen, Loader2, Pencil, Trash2, ChevronDown, Sun, Moon, Monitor, Braces, Plus, RotateCcw, Square, RefreshCw } from "lucide-svelte";
   import { tooltip } from "$lib/actions";
   import { themeList, getPreviewColors, type ThemeId } from "$lib/themes";
   import { getThemeId, setTheme, getColorMode, setColorMode, type ColorMode } from "$lib/stores/theme.svelte";
@@ -16,10 +17,12 @@
     repoId: string;
     repoName: string;
     repoPath: string;
+    lspStatusMap?: Map<string, { status: string; message: string; repo_id: string }>;
+    workspaceId?: string | null;
     onClose: () => void;
   }
 
-  let { repoId, repoName, repoPath, onClose }: Props = $props();
+  let { repoId, repoName, repoPath, lspStatusMap, workspaceId, onClose }: Props = $props();
 
   type Section = "scripts" | "agent" | "lsp" | "knowledge" | "appearance";
   let activeSection = $state<Section>("scripts");
@@ -193,6 +196,44 @@
     addingLsp = false;
     newLspId = "";
     newLspConfig = { command: "", args: [], extensions: [], language_id: "", detect_files: [], install_hint: "", project_roots: [] };
+  }
+
+  let lspBusy = $state(new Set<string>());
+
+  async function handleLspStop(serverId: string) {
+    lspBusy = new Set([...lspBusy, serverId]);
+    try {
+      await lspStopServer(repoId, serverId);
+    } catch (e) {
+      console.error("Failed to stop LSP server:", e);
+    } finally {
+      const next = new Set(lspBusy);
+      next.delete(serverId);
+      lspBusy = next;
+    }
+  }
+
+  async function handleLspRestart(serverId: string) {
+    if (!workspaceId) return;
+    lspBusy = new Set([...lspBusy, serverId]);
+    try {
+      await lspRestartServer(repoId, serverId, workspaceId);
+    } catch (e) {
+      console.error("Failed to restart LSP server:", e);
+    } finally {
+      const next = new Set(lspBusy);
+      next.delete(serverId);
+      lspBusy = next;
+    }
+  }
+
+  function getLspStatus(serverId: string): { status: string; message: string } | null {
+    if (!lspStatusMap) return null;
+    const info = lspStatusMap.get(serverId);
+    if (!info) return null;
+    // Only show status for current repo
+    if (info.repo_id && info.repo_id !== repoId) return null;
+    return info;
   }
 
   function scheduleScopeSave() {
@@ -772,6 +813,9 @@
       </p>
 
       {#each getLspEntries() as { id, config, isOverride, isCustom }}
+        {@const status = getLspStatus(id)}
+        {@const isRunning = status?.status === "ready" || status?.status === "starting" || status?.status === "indexing"}
+        {@const isBusy = lspBusy.has(id)}
         <div class="lsp-card">
           <div class="lsp-card-header">
             <span class="lsp-id">{id}</span>
@@ -783,8 +827,25 @@
               {:else}
                 <span class="lsp-badge builtin">built-in</span>
               {/if}
+              {#if status}
+                <span class="lsp-badge status-{status.status}">{status.status}</span>
+              {/if}
             </div>
             <div class="lsp-actions">
+              {#if isRunning}
+                <button class="lsp-action-btn" use:tooltip={{ text: "Stop server" }} onclick={() => handleLspStop(id)} disabled={isBusy}>
+                  <Square size={10} />
+                </button>
+              {/if}
+              {#if workspaceId}
+                <button class="lsp-action-btn" use:tooltip={{ text: "Restart server" }} onclick={() => handleLspRestart(id)} disabled={isBusy}>
+                  {#if isBusy}
+                    <Loader2 size={12} class="lsp-spin" />
+                  {:else}
+                    <RefreshCw size={12} />
+                  {/if}
+                </button>
+              {/if}
               {#if isOverride}
                 <button class="lsp-action-btn" use:tooltip={{ text: "Reset to default" }} onclick={() => resetLspServer(id)}>
                   <RotateCcw size={12} />
@@ -1659,6 +1720,27 @@
     color: var(--status-ok);
   }
 
+  .lsp-badge.status-ready {
+    background: color-mix(in srgb, var(--status-ok) 15%, transparent);
+    color: var(--status-ok);
+  }
+
+  .lsp-badge.status-starting,
+  .lsp-badge.status-indexing {
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+    color: var(--accent);
+  }
+
+  .lsp-badge.status-error {
+    background: color-mix(in srgb, var(--status-error) 15%, transparent);
+    color: var(--status-error);
+  }
+
+  .lsp-badge.status-stopped {
+    background: color-mix(in srgb, var(--text-dim) 15%, transparent);
+    color: var(--text-dim);
+  }
+
   .lsp-actions {
     display: flex;
     gap: 0.25rem;
@@ -1685,6 +1767,19 @@
   .lsp-action-btn.danger:hover {
     color: var(--status-error);
     border-color: var(--status-error);
+  }
+
+  .lsp-action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .lsp-action-btn :global(.lsp-spin) {
+    animation: lsp-spin 1s linear infinite;
+  }
+
+  @keyframes lsp-spin {
+    to { transform: rotate(360deg); }
   }
 
   .lsp-fields {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -643,8 +643,18 @@ export async function lspStartServer(workspaceId: string): Promise<void> {
   return invoke("lsp_start_server", { workspaceId });
 }
 
+/** Stop a single LSP server by repo + server ID. */
+export async function lspStopServer(repoId: string, serverId: string): Promise<void> {
+  return invoke("lsp_stop_server", { repoId, serverId });
+}
+
+/** Stop and restart a single LSP server. Needs workspaceId to resolve worktree path. */
+export async function lspRestartServer(repoId: string, serverId: string, workspaceId: string): Promise<void> {
+  return invoke("lsp_restart_server", { repoId, serverId, workspaceId });
+}
+
 /** Query current LSP server status (for populating status bar on mount). */
-export async function lspGetStatus(): Promise<{ server_id: string; status: string }[]> {
+export async function lspGetStatus(): Promise<{ repo_id: string; server_id: string; status: string }[]> {
   return invoke("lsp_get_status");
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -108,8 +108,8 @@
   let chatExpanded = $state(true);
   let terminalPaneVisible = $state(false);
 
-  // App-wide LSP status tracking
-  let lspStatusMap = $state(new Map<string, { status: string; message: string }>());
+  // App-wide LSP status tracking (keyed by server_id)
+  let lspStatusMap = $state(new Map<string, { status: string; message: string; repo_id: string }>());
   let diffRefreshTrigger = $state(0);
   let showSettings = $state(false);
   let creatingWsId = $state<string | null>(null);
@@ -613,11 +613,11 @@
 
       // LSP server lifecycle events → status bar + toast notifications
       const lspStartToasts = new Map<string, string>();
-      const unlistenLsp = await listen<{ server_id: string; status: string; message: string }>("lsp-status", (e) => {
-        const { server_id, status, message } = e.payload;
+      const unlistenLsp = await listen<{ repo_id?: string; server_id: string; status: string; message: string }>("lsp-status", (e) => {
+        const { repo_id, server_id, status, message } = e.payload;
         // Update app-wide status bar
         const next = new Map(lspStatusMap);
-        next.set(server_id, { status, message });
+        next.set(server_id, { status, message, repo_id: repo_id ?? "" });
         lspStatusMap = next;
 
         // Toast for transitions
@@ -632,6 +632,10 @@
           const prev = lspStartToasts.get(server_id);
           if (prev) { removeToast(prev); lspStartToasts.delete(server_id); }
           addToast(message, "error");
+        } else if (status === "stopped") {
+          const prev = lspStartToasts.get(server_id);
+          if (prev) { removeToast(prev); lspStartToasts.delete(server_id); }
+          addToast(message, "info");
         }
       });
 
@@ -640,7 +644,7 @@
         if (servers.length > 0) {
           const next = new Map(lspStatusMap);
           for (const s of servers) {
-            next.set(s.server_id, { status: s.status, message: `${s.server_id} ${s.status}` });
+            next.set(s.server_id, { status: s.status, message: `${s.server_id} ${s.status}`, repo_id: s.repo_id ?? "" });
           }
           lspStatusMap = next;
         }
@@ -2619,6 +2623,8 @@
         repoId={activeRepo.id}
         repoName={activeRepo.display_name}
         repoPath={activeRepo.path}
+        {lspStatusMap}
+        workspaceId={selectedWsId}
         onClose={() => {
           showSettings = false;
           if (activeRepo) {
@@ -2638,7 +2644,7 @@
       <div class="statusbar-left">
         {#each [...lspStatusMap] as [serverId, info]}
           {@const busy = info.status === "starting" || info.status === "indexing"}
-          <span class="lsp-pill" class:busy class:error={info.status === "error"} class:ready={info.status === "ready"}>
+          <span class="lsp-pill" class:busy class:error={info.status === "error"} class:ready={info.status === "ready"} class:stopped={info.status === "stopped"}>
             {#if busy}<span class="lsp-pill-spinner"></span>{/if}
             {serverId}
           </span>
@@ -3223,6 +3229,11 @@
   .lsp-pill.ready {
     background: color-mix(in srgb, var(--status-ok, #6a4) 12%, transparent);
     color: var(--status-ok, #6a4);
+  }
+
+  .lsp-pill.stopped {
+    background: color-mix(in srgb, var(--text-dim) 12%, transparent);
+    color: var(--text-dim);
   }
 
   .lsp-pill-spinner {


### PR DESCRIPTION
## Summary
- Adds per-server stop and restart buttons to the LSP section in RepoSettings
- Each LSP card shows a live status badge (ready/starting/indexing/error/stopped)
- Restart also works as "start" for servers that aren't running yet, useful after config changes or error recovery
- Refactors `lsp_start_server` to extract shared `spawn_server_background()` helper reused by the new `lsp_restart_server` command

## Test plan
- [ ] Open RepoSettings → Language Servers, verify status badges appear for running servers
- [ ] Click stop on a running server, verify it stops and badge updates
- [ ] Click restart, verify server restarts and transitions through starting → indexing → ready
- [ ] Click restart on a stopped server, verify it starts fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)