### PR TITLE
fix: prevent search modal double-trigger across mode layers

### DIFF
--- a/src/lib/components/FileBrowser.svelte
+++ b/src/lib/components/FileBrowser.svelte
@@ -182,8 +182,8 @@
   // Cmd+F / Cmd+Shift+F handler — only when this file browser is visible
   function handleGlobalKeydown(e: KeyboardEvent) {
     if (e.key === "f" && e.metaKey) {
-      // Check if this component is visible (not display:none)
-      if (browserEl && browserEl.offsetParent !== null) {
+      // Check if this component is visible (not display:none, not in inert container)
+      if (browserEl && browserEl.offsetParent !== null && !browserEl.closest("[inert]")) {
         e.preventDefault();
         e.stopPropagation();
         if (e.shiftKey) {


### PR DESCRIPTION
## Summary
- FileBrowser's `handleGlobalKeydown` used `offsetParent !== null` to check visibility, but mode layers use `visibility: hidden` (not `display: none`), so `offsetParent` remains non-null for inactive layers
- Added `!browserEl.closest("[inert]")` check to skip keyboard handling when the FileBrowser is inside an inert container, preventing the plan-mode FileBrowser from capturing ⇧⌘F when in work mode

## Test plan
- [ ] In work mode, press ⇧⌘F — only the workspace SearchModal should open, not the plan-mode FileBrowser grep
- [ ] In plan mode files view, press ⇧⌘F — grep should open normally in the plan FileBrowser


🤖 Generated with [Claude Code](https://claude.com/claude-code)