### PR TITLE
feat: add todo CRUD operations via MCP server

### DIFF
--- a/src-mcp/server.ts
+++ b/src-mcp/server.ts
@@ -151,6 +151,169 @@ server.tool(
   },
 );
 
+// ── Todo Tools ──────────────────────────────────────────────────────
+
+server.tool(
+  "create_todo",
+  "Create a new task on the Korlap kanban board's Todo column. Use this to add work items for the user or other agents to pick up.",
+  {
+    title: z.string().describe("Task title (required)"),
+    description: z
+      .string()
+      .optional()
+      .describe("Task description with details, context, or acceptance criteria"),
+  },
+  async ({ title, description }) => {
+    const { ok, data } = await apiCall("POST", "/todos/create", {
+      workspace_id: WORKSPACE_ID,
+      title,
+      description: description ?? "",
+    });
+
+    if (!ok) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Failed to create todo: ${JSON.stringify(data)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const result = data as { id: string };
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Todo created with ID: ${result.id}`,
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  "update_todo",
+  "Update an existing task on the kanban board. Use list_todos first to find the todo ID.",
+  {
+    todo_id: z.string().describe("The ID of the todo to update"),
+    title: z.string().optional().describe("New title (omit to keep current)"),
+    description: z
+      .string()
+      .optional()
+      .describe("New description (omit to keep current)"),
+  },
+  async ({ todo_id, title, description }) => {
+    const body: Record<string, unknown> = {
+      workspace_id: WORKSPACE_ID,
+      todo_id,
+    };
+    if (title !== undefined) body.title = title;
+    if (description !== undefined) body.description = description;
+
+    const { ok, data } = await apiCall("POST", "/todos/update", body);
+
+    if (!ok) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Failed to update todo: ${JSON.stringify(data)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        { type: "text" as const, text: `Todo ${todo_id} updated.` },
+      ],
+    };
+  },
+);
+
+server.tool(
+  "delete_todo",
+  "Delete a task from the kanban board. Use list_todos first to find the todo ID.",
+  {
+    todo_id: z.string().describe("The ID of the todo to delete"),
+  },
+  async ({ todo_id }) => {
+    const { ok, data } = await apiCall("POST", "/todos/delete", {
+      workspace_id: WORKSPACE_ID,
+      todo_id,
+    });
+
+    if (!ok) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Failed to delete todo: ${JSON.stringify(data)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        { type: "text" as const, text: `Todo ${todo_id} deleted.` },
+      ],
+    };
+  },
+);
+
+server.tool(
+  "list_todos",
+  "List all tasks in the kanban board's Todo column for the current repo. Returns IDs, titles, and descriptions.",
+  {},
+  async () => {
+    const { ok, data } = await apiCall(
+      "GET",
+      `/todos/list?workspace_id=${WORKSPACE_ID}`,
+    );
+
+    if (!ok) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Failed to list todos: ${JSON.stringify(data)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const todos = data as Array<{
+      id: string;
+      title: string;
+      description: string;
+    }>;
+
+    if (todos.length === 0) {
+      return {
+        content: [{ type: "text" as const, text: "No todos found." }],
+      };
+    }
+
+    const formatted = todos
+      .map(
+        (t, i) =>
+          `${i + 1}. [${t.id}] ${t.title}${t.description ? `\n   ${t.description}` : ""}`,
+      )
+      .join("\n");
+
+    return {
+      content: [{ type: "text" as const, text: formatted }],
+    };
+  },
+);
+
 // ── LSP Tools ───────────────────────────────────────────────────────
 
 server.tool(

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -92,6 +92,11 @@ fn handle_request(
         ("POST", "/lsp/workspace-symbols") => handle_lsp_workspace_symbols(&body, state, lsp_mgr, app),
         ("POST", "/lsp/diagnostics") => handle_lsp_diagnostics(&body, state, lsp_mgr, app),
         ("POST", "/lsp/rename") => handle_lsp_rename(&body, state, lsp_mgr, app),
+        // Todo routes
+        ("POST", "/todos/create") => handle_todo_create(&body, state, app),
+        ("POST", "/todos/update") => handle_todo_update(&body, state, app),
+        ("POST", "/todos/delete") => handle_todo_delete(&body, state, app),
+        ("GET", p) if p.starts_with("/todos/list") => handle_todo_list(&request_line, state),
         _ => ("404 Not Found".to_string(), r#"{"error":"not found"}"#.to_string()),
     };
 
@@ -210,6 +215,19 @@ fn handle_notify(body: &[u8], app: &AppHandle) -> (String, String) {
 }
 
 // ── LSP handlers ────────────────────────────────────────────────────
+
+/// Resolve workspace_id → repo_id only.
+fn resolve_workspace_repo_id(
+    state: &Arc<Mutex<AppState>>,
+    workspace_id: &str,
+) -> Result<String, String> {
+    let st = state.lock().map_err(|e| e.to_string())?;
+    let ws = st
+        .workspaces
+        .get(workspace_id)
+        .ok_or_else(|| "workspace not found".to_string())?;
+    Ok(ws.repo_id.clone())
+}
 
 /// Resolve workspace_id → (repo_id, repo_path, worktree_path).
 fn resolve_workspace(
@@ -700,4 +718,218 @@ fn handle_lsp_rename(
             format!(r#"{{"error":"Failed to apply rename: {}"}}"#, e),
         ),
     }
+}
+
+// ── Todo handlers ───────────────────────────────────────────────────
+
+/// Read the todos JSON file for a repo, returning an array of todo objects.
+fn read_todos(state: &Arc<Mutex<AppState>>, repo_id: &str) -> Result<Vec<serde_json::Value>, String> {
+    let todos_file = {
+        let st = state.lock().map_err(|e| e.to_string())?;
+        st.todos_dir().join(format!("{}.json", repo_id))
+    };
+    if !todos_file.exists() {
+        return Ok(Vec::new());
+    }
+    let data = std::fs::read_to_string(&todos_file).map_err(|e| e.to_string())?;
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+    Ok(arr)
+}
+
+/// Write the todos array back to disk.
+fn write_todos(state: &Arc<Mutex<AppState>>, repo_id: &str, todos: &[serde_json::Value]) -> Result<(), String> {
+    let todos_dir = {
+        let st = state.lock().map_err(|e| e.to_string())?;
+        st.todos_dir()
+    };
+    std::fs::create_dir_all(&todos_dir).map_err(|e| e.to_string())?;
+    let todos_file = todos_dir.join(format!("{}.json", repo_id));
+    let data = serde_json::to_string(todos).map_err(|e| e.to_string())?;
+    std::fs::write(&todos_file, data).map_err(|e| e.to_string())
+}
+
+fn handle_todo_create(
+    body: &[u8],
+    state: &Arc<Mutex<AppState>>,
+    app: &AppHandle,
+) -> (String, String) {
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return ("400 Bad Request".into(), r#"{"error":"invalid json"}"#.into());
+    };
+
+    let workspace_id = match v.get("workspace_id").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return ("400 Bad Request".into(), r#"{"error":"missing workspace_id"}"#.into()),
+    };
+    let title = match v.get("title").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return ("400 Bad Request".into(), r#"{"error":"missing title"}"#.into()),
+    };
+    let description = v.get("description").and_then(|s| s.as_str()).unwrap_or("").to_string();
+
+    let repo_id = match resolve_workspace_repo_id(state, &workspace_id) {
+        Ok(id) => id,
+        Err(e) => return ("404 Not Found".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let mut todos = match read_todos(state, &repo_id) {
+        Ok(t) => t,
+        Err(e) => return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let todo_id = uuid::Uuid::new_v4().to_string();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+
+    let todo = serde_json::json!({
+        "id": todo_id,
+        "repo_id": repo_id,
+        "title": title,
+        "description": description,
+        "created_at": now,
+    });
+    todos.push(todo);
+
+    if let Err(e) = write_todos(state, &repo_id, &todos) {
+        return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e));
+    }
+
+    let _ = app.emit("todos-changed", serde_json::json!({ "repo_id": repo_id }));
+
+    (
+        "200 OK".into(),
+        serde_json::json!({ "ok": true, "id": todo_id }).to_string(),
+    )
+}
+
+fn handle_todo_update(
+    body: &[u8],
+    state: &Arc<Mutex<AppState>>,
+    app: &AppHandle,
+) -> (String, String) {
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return ("400 Bad Request".into(), r#"{"error":"invalid json"}"#.into());
+    };
+
+    let workspace_id = match v.get("workspace_id").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return ("400 Bad Request".into(), r#"{"error":"missing workspace_id"}"#.into()),
+    };
+    let todo_id = match v.get("todo_id").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return ("400 Bad Request".into(), r#"{"error":"missing todo_id"}"#.into()),
+    };
+
+    let repo_id = match resolve_workspace_repo_id(state, &workspace_id) {
+        Ok(id) => id,
+        Err(e) => return ("404 Not Found".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let mut todos = match read_todos(state, &repo_id) {
+        Ok(t) => t,
+        Err(e) => return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let Some(todo) = todos.iter_mut().find(|t| t.get("id").and_then(|i| i.as_str()) == Some(&todo_id)) else {
+        return ("404 Not Found".into(), r#"{"error":"todo not found"}"#.into());
+    };
+
+    // Apply partial updates
+    if let Some(title) = v.get("title").and_then(|s| s.as_str()) {
+        todo["title"] = serde_json::Value::String(title.to_string());
+    }
+    if let Some(desc) = v.get("description").and_then(|s| s.as_str()) {
+        todo["description"] = serde_json::Value::String(desc.to_string());
+    }
+
+    if let Err(e) = write_todos(state, &repo_id, &todos) {
+        return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e));
+    }
+
+    let _ = app.emit("todos-changed", serde_json::json!({ "repo_id": repo_id }));
+
+    ("200 OK".into(), r#"{"ok":true}"#.into())
+}
+
+fn handle_todo_delete(
+    body: &[u8],
+    state: &Arc<Mutex<AppState>>,
+    app: &AppHandle,
+) -> (String, String) {
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return ("400 Bad Request".into(), r#"{"error":"invalid json"}"#.into());
+    };
+
+    let workspace_id = match v.get("workspace_id").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return ("400 Bad Request".into(), r#"{"error":"missing workspace_id"}"#.into()),
+    };
+    let todo_id = match v.get("todo_id").and_then(|s| s.as_str()) {
+        Some(s) => s.to_string(),
+        None => return ("400 Bad Request".into(), r#"{"error":"missing todo_id"}"#.into()),
+    };
+
+    let repo_id = match resolve_workspace_repo_id(state, &workspace_id) {
+        Ok(id) => id,
+        Err(e) => return ("404 Not Found".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let mut todos = match read_todos(state, &repo_id) {
+        Ok(t) => t,
+        Err(e) => return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let before_len = todos.len();
+    todos.retain(|t| t.get("id").and_then(|i| i.as_str()) != Some(&todo_id));
+
+    if todos.len() == before_len {
+        return ("404 Not Found".into(), r#"{"error":"todo not found"}"#.into());
+    }
+
+    if let Err(e) = write_todos(state, &repo_id, &todos) {
+        return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e));
+    }
+
+    let _ = app.emit("todos-changed", serde_json::json!({ "repo_id": repo_id }));
+
+    ("200 OK".into(), r#"{"ok":true}"#.into())
+}
+
+fn handle_todo_list(
+    request_line: &str,
+    state: &Arc<Mutex<AppState>>,
+) -> (String, String) {
+    let workspace_id = request_line
+        .split('?')
+        .nth(1)
+        .and_then(|qs| {
+            qs.split('&').find_map(|param| {
+                let mut kv = param.split('=');
+                if kv.next()? == "workspace_id" {
+                    kv.next().map(|v| v.split_whitespace().next().unwrap_or(v).to_string())
+                } else {
+                    None
+                }
+            })
+        });
+
+    let workspace_id = match workspace_id {
+        Some(id) => id,
+        None => return ("400 Bad Request".into(), r#"{"error":"missing workspace_id"}"#.into()),
+    };
+
+    let repo_id = match resolve_workspace_repo_id(state, &workspace_id) {
+        Ok(id) => id,
+        Err(e) => return ("404 Not Found".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let todos = match read_todos(state, &repo_id) {
+        Ok(t) => t,
+        Err(e) => return ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let json = serde_json::to_string(&todos).unwrap_or_else(|_| "[]".to_string());
+    ("200 OK".into(), json)
 }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -787,6 +787,12 @@ export function onWorkspaceUpdated(
   return listen<WorkspaceInfo>("workspace-updated", (e) => callback(e.payload));
 }
 
+export function onTodosChanged(
+  callback: (event: { repo_id: string }) => void,
+): Promise<UnlistenFn> {
+  return listen<{ repo_id: string }>("todos-changed", (e) => callback(e.payload));
+}
+
 // ── Suggested replies ────────────────────────────────────────────────
 
 export async function suggestReplies(text: string): Promise<string[]> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,7 @@
     saveImage,
     onAgentStatus,
     onWorkspaceUpdated,
+    onTodosChanged,
     stopAgent,
     renameBranch,
     getRepoSettings,
@@ -575,6 +576,7 @@
   onMount(() => {
     let unlistenStatus: (() => void) | undefined;
     let unlistenWsUpdate: (() => void) | undefined;
+    let unlistenTodos: (() => void) | undefined;
 
     (async () => {
       listModels().catch(() => {}); // pre-populate model cache
@@ -608,6 +610,14 @@
         const idx = workspaces.findIndex((w) => w.id === updated.id);
         if (idx >= 0) {
           workspaces[idx] = updated;
+        }
+      });
+
+      unlistenTodos = await onTodosChanged(({ repo_id }) => {
+        if (activeRepo && repo_id === activeRepo.id) {
+          loadTodos(repo_id).then((raw) => {
+            todos = (raw as TodoItem[]) ?? [];
+          }).catch(() => {});
         }
       });
 
@@ -814,6 +824,7 @@
     return () => {
       unlistenStatus?.();
       unlistenWsUpdate?.();
+      unlistenTodos?.();
       clearInterval(prPollInterval);
       clearInterval(basePollInterval);
       window.removeEventListener("keydown", handleKeydown);


### PR DESCRIPTION
## Summary
- Adds `create_todo`, `update_todo`, `delete_todo`, and `list_todos` MCP tools so agents can manage kanban board tasks
- Backend routes in `mcp_api.rs` resolve workspace → repo, read/write the todos JSON file, and emit `todos-changed` events
- Frontend listens for `todos-changed` to reload todos from disk, keeping the kanban board in sync when agents mutate tasks

## Test plan
- [ ] Agent calls `create_todo` with title/description → todo appears on kanban board
- [ ] Agent calls `list_todos` → returns all todos with IDs
- [ ] Agent calls `update_todo` with partial fields → kanban card updates in real time
- [ ] Agent calls `delete_todo` → todo disappears from board
- [ ] Verify todos persist across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)