### PR TITLE
fix: widen task popover dialog from 540px to 640px

### DIFF
--- a/src/lib/components/TaskPopover.svelte
+++ b/src/lib/components/TaskPopover.svelte
@@ -514,7 +514,7 @@
   }
 
   .dialog {
-    width: 540px;
+    width: 640px;
     max-width: 90vw;
     max-height: 80vh;
     display: flex;


### PR DESCRIPTION
## Summary
- Widened the TaskPopover dialog from 540px to 640px to give footer buttons (Thinking, Plan, model/provider dropdowns, Cancel, Add & Start, Add) more breathing room

## Test plan
- [ ] Open the task popover and verify buttons are no longer cramped
- [ ] Confirm dialog stays within viewport on smaller screens (max-width: 90vw still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)