### PR TITLE
fix: inject shell env into all git/terminal commands, support non-zsh shells

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -3,6 +3,17 @@ use crate::state::AppState;
 use std::sync::{Arc, Mutex};
 use tauri::State;
 
+use super::helpers::inject_shell_env;
+
+/// Return a `git` Command with the full user shell environment injected.
+/// Without this, commands spawned from a Finder/Dock-launched Tauri app would
+/// get a minimal PATH that is missing ~/.local/bin, Homebrew paths, etc.
+fn git_cmd() -> std::process::Command {
+    let mut cmd = std::process::Command::new("git");
+    inject_shell_env(&mut cmd);
+    cmd
+}
+
 // ── Repo branch commands ────────────────────────────────────────────
 
 #[tauri::command]
@@ -16,7 +27,7 @@ pub fn get_repo_head(
         repo.path.clone()
     };
 
-    let output = std::process::Command::new("git")
+    let output = git_cmd()
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(&repo_path)
         .output()
@@ -44,7 +55,7 @@ pub async fn checkout_default_branch(
     };
 
     tauri::async_runtime::spawn_blocking(move || {
-        let output = std::process::Command::new("git")
+        let output = git_cmd()
             .args(["checkout", &default_branch])
             .current_dir(&repo_path)
             .output()
@@ -96,7 +107,7 @@ pub async fn get_changed_files(
         // Compare against origin/<base> since workspaces branch from the remote tip.
         // Using the local base branch would show phantom diffs when local is behind remote.
         let remote_base = format!("origin/{}", base_branch);
-        let merge_base = std::process::Command::new("git")
+        let merge_base = git_cmd()
             .args(["merge-base", &remote_base, "HEAD"])
             .current_dir(&worktree_path)
             .output()
@@ -106,7 +117,7 @@ pub async fn get_changed_files(
             } else { None })
             .unwrap_or_else(|| remote_base.clone());
 
-        let output = std::process::Command::new("git")
+        let output = git_cmd()
             .args(["diff", "--numstat", &merge_base])
             .current_dir(&worktree_path)
             .output()
@@ -142,7 +153,7 @@ pub async fn get_changed_files(
             }
         }
 
-        let untracked = std::process::Command::new("git")
+        let untracked = git_cmd()
             .args(["ls-files", "--others", "--exclude-standard"])
             .current_dir(&worktree_path)
             .output()
@@ -191,7 +202,7 @@ pub async fn get_diff(
     tauri::async_runtime::spawn_blocking(move || {
         // Compare against origin/<base> since workspaces branch from the remote tip.
         let remote_base = format!("origin/{}", base_branch);
-        let merge_base = std::process::Command::new("git")
+        let merge_base = git_cmd()
             .args(["merge-base", &remote_base, "HEAD"])
             .current_dir(&worktree_path)
             .output()
@@ -201,7 +212,7 @@ pub async fn get_diff(
             } else { None })
             .unwrap_or_else(|| remote_base.clone());
 
-        let mut cmd = std::process::Command::new("git");
+        let mut cmd = git_cmd();
         cmd.args(["diff", &merge_base]);
         if let Some(ref fp) = file_path {
             cmd.arg("--").arg(fp);
@@ -267,7 +278,7 @@ pub async fn git_commit(
     let msg = message.clone();
     tauri::async_runtime::spawn_blocking(move || {
         // Stage all changes
-        let add_output = std::process::Command::new("git")
+        let add_output = git_cmd()
             .args(["add", "-A"])
             .current_dir(&worktree_path)
             .output()
@@ -278,7 +289,7 @@ pub async fn git_commit(
         }
 
         // Check if there's anything to commit
-        let diff_check = std::process::Command::new("git")
+        let diff_check = git_cmd()
             .args(["diff", "--cached", "--quiet"])
             .current_dir(&worktree_path)
             .status()
@@ -288,7 +299,7 @@ pub async fn git_commit(
         }
 
         // Commit
-        let commit_output = std::process::Command::new("git")
+        let commit_output = git_cmd()
             .args(["commit", "-m", &msg])
             .current_dir(&worktree_path)
             .output()
@@ -299,7 +310,7 @@ pub async fn git_commit(
         }
 
         // Get the short hash of the new commit
-        let hash_output = std::process::Command::new("git")
+        let hash_output = git_cmd()
             .args(["rev-parse", "--short", "HEAD"])
             .current_dir(&worktree_path)
             .output()
@@ -332,7 +343,7 @@ pub async fn git_push(
         let gh_token = provider.resolve_token(&gh_profile);
 
         // Use actual git branch — metadata may be stale after a rename failure
-        let branch = std::process::Command::new("git")
+        let branch = git_cmd()
             .args(["branch", "--show-current"])
             .current_dir(&worktree_path)
             .output()
@@ -388,7 +399,7 @@ pub async fn check_main_behind(
         }
 
         // Count commits local is behind: main..origin/main
-        let rev_list = std::process::Command::new("git")
+        let rev_list = git_cmd()
             .args([
                 "rev-list", "--count",
                 &format!("{}..origin/{}", base_branch, base_branch),
@@ -449,7 +460,7 @@ pub async fn sync_main(
         }
 
         // 2. Check if HEAD is on the default branch
-        let head_output = std::process::Command::new("git")
+        let head_output = git_cmd()
             .args(["rev-parse", "--abbrev-ref", "HEAD"])
             .current_dir(&repo_path)
             .output()
@@ -458,7 +469,7 @@ pub async fn sync_main(
 
         if current_branch == base_branch {
             // HEAD is on the default branch — must update working tree too
-            let output = std::process::Command::new("git")
+            let output = git_cmd()
                 .args(["merge", "--ff-only", &format!("origin/{}", base_branch)])
                 .current_dir(&repo_path)
                 .output()
@@ -470,7 +481,7 @@ pub async fn sync_main(
             }
         } else {
             // Default branch not checked out — safe to just move the ref
-            let output = std::process::Command::new("git")
+            let output = git_cmd()
                 .args([
                     "update-ref",
                     &format!("refs/heads/{}", base_branch),
@@ -532,7 +543,7 @@ pub async fn check_base_updates(
         let remote_base = format!("origin/{}", base_branch);
 
         // Find merge-base between HEAD and origin/<base>
-        let merge_base_output = std::process::Command::new("git")
+        let merge_base_output = git_cmd()
             .args(["merge-base", "HEAD", &remote_base])
             .current_dir(&worktree_path)
             .output()
@@ -548,7 +559,7 @@ pub async fn check_base_updates(
             .to_string();
 
         // Count commits on origin/<base> since the merge-base
-        let rev_list = std::process::Command::new("git")
+        let rev_list = git_cmd()
             .args(["rev-list", "--count", &format!("{}..{}", merge_base, remote_base)])
             .current_dir(&worktree_path)
             .output()
@@ -607,7 +618,7 @@ pub async fn update_from_base(
 
         // Merge origin/<base> into the workspace branch
         let remote_base = format!("origin/{}", base_branch);
-        let merge_output = std::process::Command::new("git")
+        let merge_output = git_cmd()
             .args(["merge", &remote_base, "--no-edit"])
             .current_dir(&worktree_path)
             .output()
@@ -618,7 +629,7 @@ pub async fn update_from_base(
             let stdout = String::from_utf8_lossy(&merge_output.stdout);
 
             // Abort the failed merge to leave worktree clean
-            let _ = std::process::Command::new("git")
+            let _ = git_cmd()
                 .args(["merge", "--abort"])
                 .current_dir(&worktree_path)
                 .output();

--- a/src-tauri/src/commands/helpers.rs
+++ b/src-tauri/src/commands/helpers.rs
@@ -56,11 +56,45 @@ pub fn repo_display_name(repo_path: &Path) -> String {
         .unwrap_or_else(|| repo_path.display().to_string())
 }
 
+/// Build a Command that runs `script` inside the user's login shell.
+/// Handles shell-specific arg differences:
+///   zsh/bash: `<shell> -lic "<script>"`
+///   fish:     `fish --login --interactive -c "<script>"`
+fn login_shell_cmd(shell: &str, script: &str) -> std::process::Command {
+    let shell_name = Path::new(shell)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let mut cmd = std::process::Command::new(shell);
+    if shell_name == "fish" {
+        cmd.args(["--login", "--interactive", "-c", script]);
+    } else {
+        // zsh, bash, and other POSIX-ish shells all accept -lic
+        cmd.args(["-lic", script]);
+    }
+    cmd.stderr(std::process::Stdio::null());
+    cmd
+}
+
+/// Extract the delimited value from noisy shell output.
+/// Returns the trimmed text between the first pair of `delimiter` markers.
+fn extract_delimited(stdout: &str, delimiter: &str) -> Option<String> {
+    let mut parts = stdout.split(delimiter);
+    let _before = parts.next(); // noise before first delimiter
+    let value = parts.next()?;
+    let trimmed = value.trim().to_string();
+    if trimmed.is_empty() { None } else { Some(trimmed) }
+}
+
 /// Cached shell env values (resolved once on first call).
 pub fn get_shell_env() -> &'static ShellEnv {
     use std::sync::OnceLock;
     static ENV: OnceLock<ShellEnv> = OnceLock::new();
     ENV.get_or_init(|| {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        tracing::info!("Resolving shell environment using {}", shell);
+
         let ssh_auth_sock = std::env::var("SSH_AUTH_SOCK").ok().or_else(|| {
             std::process::Command::new("launchctl")
                 .args(["getenv", "SSH_AUTH_SOCK"])
@@ -74,69 +108,43 @@ pub fn get_shell_env() -> &'static ShellEnv {
 
         let home = std::env::var("HOME").ok();
 
-        // Use interactive login shell (-lic) so .zshrc is sourced — this is
+        // Use interactive login shell so rc files are sourced — this is
         // where nvm/fnm/volta add their PATH entries.  Delimiters protect
-        // against noisy .zshrc output (motd, nvm "now using", etc.).
+        // against noisy shell output (motd, nvm "now using", etc.).
         let delimiter = "__KORLAP_ENV__";
-        let path = std::process::Command::new("zsh")
-            .args([
-                "-lic",
+        let path = login_shell_cmd(
+                &shell,
                 &format!("echo {delimiter}; echo $PATH; echo {delimiter}"),
-            ])
-            .stderr(std::process::Stdio::null())
+            )
             .output()
             .ok()
-            .and_then(|o| {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                let mut parts = stdout.split(delimiter);
-                let _before = parts.next(); // noise before first delimiter
-                let value = parts.next()?;  // the actual PATH
-                let trimmed = value.trim().to_string();
-                if trimmed.is_empty() { None } else { Some(trimmed) }
-            });
+            .and_then(|o| extract_delimited(&String::from_utf8_lossy(&o.stdout), delimiter));
 
         // Resolve absolute path to `claude` binary once, so we don't rely
         // on PATH lookup at every spawn (which can fail in sandboxed contexts).
-        let claude_path = std::process::Command::new("zsh")
-            .args(["-lic", &format!("echo {delimiter}; whence -p claude; echo {delimiter}")])
-            .stderr(std::process::Stdio::null())
+        // `command -v` is POSIX and works in bash, zsh, and fish.
+        let claude_path = login_shell_cmd(
+                &shell,
+                &format!("echo {delimiter}; command -v claude; echo {delimiter}"),
+            )
             .output()
             .ok()
-            .and_then(|o| {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                let mut parts = stdout.split(delimiter);
-                let _before = parts.next();
-                let value = parts.next()?;
-                let trimmed = value.trim().to_string();
-                if trimmed.is_empty() || trimmed.contains("not found") {
-                    None
-                } else {
-                    Some(trimmed)
-                }
-            });
+            .and_then(|o| extract_delimited(&String::from_utf8_lossy(&o.stdout), delimiter))
+            .filter(|s| !s.contains("not found"));
 
         if claude_path.is_none() {
             tracing::warn!("Could not resolve `claude` binary path — agent spawn will likely fail");
         }
 
         // Resolve codex binary path (optional — only needed if user selects Codex provider)
-        let codex_path = std::process::Command::new("zsh")
-            .args(["-lic", &format!("echo {delimiter}; whence -p codex; echo {delimiter}")])
-            .stderr(std::process::Stdio::null())
+        let codex_path = login_shell_cmd(
+                &shell,
+                &format!("echo {delimiter}; command -v codex; echo {delimiter}"),
+            )
             .output()
             .ok()
-            .and_then(|o| {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                let mut parts = stdout.split(delimiter);
-                let _before = parts.next();
-                let value = parts.next()?;
-                let trimmed = value.trim().to_string();
-                if trimmed.is_empty() || trimmed.contains("not found") {
-                    None
-                } else {
-                    Some(trimmed)
-                }
-            });
+            .and_then(|o| extract_delimited(&String::from_utf8_lossy(&o.stdout), delimiter))
+            .filter(|s| !s.contains("not found"));
 
         if codex_path.is_some() {
             tracing::info!("Resolved codex binary: {:?}", codex_path);
@@ -145,12 +153,10 @@ pub fn get_shell_env() -> &'static ShellEnv {
         // Capture full environment from interactive login shell so spawned
         // processes get all user env vars (CARGO_TARGET_DIR, GOPATH, etc.)
         // that a Tauri app launched from Finder/Dock would otherwise miss.
-        let all_vars: HashMap<String, String> = std::process::Command::new("zsh")
-            .args([
-                "-lic",
+        let all_vars: HashMap<String, String> = login_shell_cmd(
+                &shell,
                 &format!("echo {delimiter}; /usr/bin/env; echo {delimiter}"),
-            ])
-            .stderr(std::process::Stdio::null())
+            )
             .output()
             .ok()
             .and_then(|o| {
@@ -197,8 +203,9 @@ pub fn get_shell_env() -> &'static ShellEnv {
             .unwrap_or_default();
 
         tracing::info!(
-            "Captured {} env vars from login shell",
-            all_vars.len()
+            "Captured {} env vars from login shell ({})",
+            all_vars.len(),
+            shell,
         );
 
         ShellEnv { ssh_auth_sock, home, path, claude_path, codex_path, all_vars }

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -68,11 +68,12 @@ pub async fn create_staging_workspace(
             // Remove worktree
             if let Some(ref path) = existing_path {
                 if path.exists() {
-                    let _ = std::process::Command::new("git")
-                        .args(["worktree", "remove", "--force"])
+                    let mut rm_cmd = std::process::Command::new("git");
+                    rm_cmd.args(["worktree", "remove", "--force"])
                         .arg(path)
-                        .current_dir(&repo_path)
-                        .output();
+                        .current_dir(&repo_path);
+                    inject_shell_env(&mut rm_cmd);
+                    let _ = rm_cmd.output();
                 }
             }
 
@@ -97,25 +98,28 @@ pub async fn create_staging_workspace(
 
     // Always clean up stale worktree/branch even if not tracked in state
     if worktree_path.exists() {
-        let _ = std::process::Command::new("git")
-            .args(["worktree", "remove", "--force"])
+        let mut rm_wt = std::process::Command::new("git");
+        rm_wt.args(["worktree", "remove", "--force"])
             .arg(&worktree_path)
-            .current_dir(&repo_path)
-            .output();
+            .current_dir(&repo_path);
+        inject_shell_env(&mut rm_wt);
+        let _ = rm_wt.output();
     }
     // Migration: clean up old shared "staging" path from before per-repo paths
     let old_staging_path = worktree_base.join("staging");
     if old_staging_path.exists() {
-        let _ = std::process::Command::new("git")
-            .args(["worktree", "remove", "--force"])
+        let mut rm_old = std::process::Command::new("git");
+        rm_old.args(["worktree", "remove", "--force"])
             .arg(&old_staging_path)
-            .current_dir(&repo_path)
-            .output();
+            .current_dir(&repo_path);
+        inject_shell_env(&mut rm_old);
+        let _ = rm_old.output();
     }
-    let _ = std::process::Command::new("git")
-        .args(["worktree", "prune"])
-        .current_dir(&repo_path)
-        .output();
+    let mut prune_cmd = std::process::Command::new("git");
+    prune_cmd.args(["worktree", "prune"])
+        .current_dir(&repo_path);
+    inject_shell_env(&mut prune_cmd);
+    let _ = prune_cmd.output();
     let mut stale_del = std::process::Command::new("git");
     stale_del
         .args(["branch", "-D", "korlap/staging"])
@@ -126,12 +130,13 @@ pub async fn create_staging_workspace(
     std::fs::create_dir_all(worktree_path.parent().unwrap_or(&worktree_path))
         .map_err(|e| e.to_string())?;
 
-    let output = std::process::Command::new("git")
-        .args(["worktree", "add", "-b", "korlap/staging"])
+    let mut wt_add = std::process::Command::new("git");
+    wt_add.args(["worktree", "add", "-b", "korlap/staging"])
         .arg(&worktree_path)
         .arg(&start_point)
-        .current_dir(&repo_path)
-        .output()
+        .current_dir(&repo_path);
+    inject_shell_env(&mut wt_add);
+    let output = wt_add.output()
         .map_err(|e| format!("Failed to run git worktree add: {}", e))?;
 
     if !output.status.success() {
@@ -256,24 +261,27 @@ pub async fn remove_staging_workspace(
 
     // Remove worktree
     if worktree_path.exists() {
-        let output = std::process::Command::new("git")
-            .args(["worktree", "remove", "--force"])
+        let mut rm_wt = std::process::Command::new("git");
+        rm_wt.args(["worktree", "remove", "--force"])
             .arg(&worktree_path)
-            .current_dir(&repo_path)
-            .output()
+            .current_dir(&repo_path);
+        inject_shell_env(&mut rm_wt);
+        let output = rm_wt.output()
             .map_err(|e| format!("Failed to remove worktree: {}", e))?;
 
         if !output.status.success() {
-            let _ = std::process::Command::new("git")
-                .args(["worktree", "prune"])
-                .current_dir(&repo_path)
-                .output();
+            let mut prune = std::process::Command::new("git");
+            prune.args(["worktree", "prune"])
+                .current_dir(&repo_path);
+            inject_shell_env(&mut prune);
+            let _ = prune.output();
         }
     } else {
-        let _ = std::process::Command::new("git")
-            .args(["worktree", "prune"])
-            .current_dir(&repo_path)
-            .output();
+        let mut prune = std::process::Command::new("git");
+        prune.args(["worktree", "prune"])
+            .current_dir(&repo_path);
+        inject_shell_env(&mut prune);
+        let _ = prune.output();
     }
 
     // Delete the staging branch

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -86,28 +86,16 @@ fn spawn_pty(
     cmd.env("LANG", &lang);
     cmd.env("LC_ALL", &lang);
 
-    // Inject shell env for SSH, PATH, etc.
-    if let Ok(sock) = std::env::var("SSH_AUTH_SOCK") {
-        cmd.env("SSH_AUTH_SOCK", sock);
-    } else if let Ok(output) = std::process::Command::new("launchctl")
-        .args(["getenv", "SSH_AUTH_SOCK"])
-        .output()
-    {
-        let sock = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !sock.is_empty() {
+    // Inject cached shell env (PATH, SSH_AUTH_SOCK, HOME, GOPATH, etc.)
+    // so the PTY inherits the same environment as agent/git commands.
+    let shell_env = super::helpers::get_shell_env();
+    for (key, value) in &shell_env.all_vars {
+        cmd.env(key, value);
+    }
+    // Fallback: SSH_AUTH_SOCK from launchctl if not in shell env
+    if !shell_env.all_vars.contains_key("SSH_AUTH_SOCK") {
+        if let Some(ref sock) = shell_env.ssh_auth_sock {
             cmd.env("SSH_AUTH_SOCK", sock);
-        }
-    }
-    if let Ok(home) = std::env::var("HOME") {
-        cmd.env("HOME", home);
-    }
-    if let Ok(output) = std::process::Command::new("zsh")
-        .args(["-l", "-c", "echo $PATH"])
-        .output()
-    {
-        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !path.is_empty() {
-            cmd.env("PATH", path);
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -392,11 +392,12 @@ impl AppState {
     }
 
     pub fn is_git_repo(path: &Path) -> Result<(), String> {
-        let output = std::process::Command::new("git")
-            .arg("rev-parse")
+        let mut cmd = std::process::Command::new("git");
+        cmd.arg("rev-parse")
             .arg("--git-dir")
-            .current_dir(path)
-            .output()
+            .current_dir(path);
+        crate::commands::helpers::inject_shell_env(&mut cmd);
+        let output = cmd.output()
             .map_err(|e| format!("Failed to run git: {}", e))?;
         if !output.status.success() {
             return Err(format!("{} is not a git repository", path.display()));
@@ -438,11 +439,11 @@ fn extract_task_from_messages(messages_dir: &Path, workspace_id: &str) -> Option
 /// rather than trusting stored metadata (the agent may have already renamed
 /// it via a bash command). No-ops if the branch is already at the target name.
 pub fn rename_git_branch(worktree_path: &Path, new_branch: &str, fallback_branch: &str) -> Result<(), String> {
-    let current_branch = match std::process::Command::new("git")
-        .args(["branch", "--show-current"])
-        .current_dir(worktree_path)
-        .output()
-    {
+    let mut show_cmd = std::process::Command::new("git");
+    show_cmd.args(["branch", "--show-current"])
+        .current_dir(worktree_path);
+    crate::commands::helpers::inject_shell_env(&mut show_cmd);
+    let current_branch = match show_cmd.output() {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
         _ => fallback_branch.to_string(),
     };
@@ -451,10 +452,11 @@ pub fn rename_git_branch(worktree_path: &Path, new_branch: &str, fallback_branch
         return Ok(());
     }
 
-    let output = std::process::Command::new("git")
-        .args(["branch", "-m", &current_branch, new_branch])
-        .current_dir(worktree_path)
-        .output()
+    let mut rename_cmd = std::process::Command::new("git");
+    rename_cmd.args(["branch", "-m", &current_branch, new_branch])
+        .current_dir(worktree_path);
+    crate::commands::helpers::inject_shell_env(&mut rename_cmd);
+    let output = rename_cmd.output()
         .map_err(|e| format!("Failed to run git branch -m: {}", e))?;
 
     if !output.status.success() {


### PR DESCRIPTION
## Summary
- `git.rs`, `state.rs`, and `staging.rs` had bare `Command::new("git")` calls with no shell env injection, so commands spawned from Finder/Dock got a minimal PATH missing `~/.local/bin`, Homebrew paths, etc.
- `terminal.rs` had ad-hoc env setup that spawned a fresh `zsh -l -c` on every terminal open instead of using the cached shell env.
- Shell env resolution was hardcoded to `zsh` with zsh-only `whence -p`. Now reads `$SHELL`, handles fish args (`--login --interactive -c`), and uses POSIX `command -v` for binary lookup.

## Test plan
- [ ] Launch app from Dock, open terminal — verify commands in `~/.local/bin` are found
- [ ] Create workspace, run agent — verify `claude` binary resolves correctly
- [ ] Git operations (diff, commit, push) work from workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)